### PR TITLE
Adding ability to set/override the namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The metrics-agent collects allocation metrics from a container orchestration sys
 
 ## Kubernetes
 
-The agent requires that it runs in a namespace named "cloudability" with a service account, pulling metrics from the Kubernetes API and [Heapster](https://github.com/kubernetes/heapster).  The agent will attempt to connect to heapster, and if unable to communicate with it, the agent will launch Heapster as a service in the cloudability namespace. An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml).
+The agent will default to the "cloudability" namespace, but it can be overridden by specifying `CLOUDABILITY_NAMESPACE` or `--namespace=<NAMESPACE>` on the command-line. Once deployed, along with a service account, it will being pulling metrics from the Kubernetes API and [Heapster](https://github.com/kubernetes/heapster).  The agent will attempt to connect to heapster, and if unable to communicate with it, the agent will launch Heapster as a service in the cloudability namespace. An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml).
 
 ### Configuration Options
 
@@ -19,9 +19,10 @@ The agent requires that it runs in a namespace named "cloudability" with a servi
 | CLOUDABILITY_HEAPSTER_URL               | Optional: Only required if heapster is not deployed as a service in your cluster or is only accessable via a specific URL.           |
 | CLOUDABILITY_OUTBOUND_PROXY             | Optional: The URL of an outbound HTTP/HTTPS proxy for the agent to use (eg: http://x.x.x.x:8080). The URL must contain the scheme prefix (http:// or https://)  |
 | CLOUDABILITY_OUTBOUND_PROXY_AUTH        | Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password |
-| CLOUDABILITY_OUTBOUND_PROXY_INSECURE        | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
-| CLOUDABILITY_INSECURE        | Optional: When true, does not verify certificates when making TLS connections. Default: False|
-| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES        | Optional: When true, collects metrics directly from each node in a cluster. Default: False|
+| CLOUDABILITY_OUTBOUND_PROXY_INSECURE    | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
+| CLOUDABILITY_INSECURE                   | Optional: When true, does not verify certificates when making TLS connections. Default: False|
+| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. Default: False|
+| CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent is running it Default: `cloudability`|
 
 ```sh
 
@@ -43,6 +44,7 @@ Flags:
       --outbound_proxy_auth string               Outbound proxy basic authentication credentials. Must defined in the form username:password - Optional
       --outbound_proxy_insecure                  When true, does not verify TLS certificates when using the outbound proxy. Default: False
       --poll_interval int                        Time, in seconds, to poll the services infrastructure. Default: 180 (default 180)
+      --namespace string                         The namespace which the agent is running inside of (default `cloudability`)
 ```
 
 ## Development

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -110,7 +110,7 @@ func init() {
 	_ = viper.BindPFlag("outbound_proxy_insecure", kubernetesCmd.PersistentFlags().Lookup("outbound_proxy_insecure"))
 	_ = viper.BindPFlag("insecure", kubernetesCmd.PersistentFlags().Lookup("insecure"))
 	_ = viper.BindPFlag("retrieve_node_summaries", kubernetesCmd.PersistentFlags().Lookup("retrieve_node_summaries"))
-    _ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
+	_ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
 
 	viper.SetEnvPrefix("cloudability")
 	viper.AutomaticEnv()

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -91,12 +91,12 @@ func init() {
 		false,
 		"When true, includes node summary metrics in metric collection. Default: False",
 	)
-    kubernetesCmd.PersistentFlags().StringVar(
-        &config.Namespace,
-        "namespace",
-        "",
-        "Kubernetes Namespace that the Agent is Running In",
-    )
+	kubernetesCmd.PersistentFlags().StringVar(
+		&config.Namespace,
+		"namespace",
+		"cloudability",
+		"Kubernetes Namespace that the Agent is Running In",
+	)
 
 	//nolint gas
 	_ = viper.BindPFlag("api_key", kubernetesCmd.PersistentFlags().Lookup("api_key"))
@@ -133,6 +133,7 @@ func init() {
 		Cert:                  viper.GetString("certificate_file"),
 		Key:                   viper.GetString("key_file"),
 		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
+		Namespace:             viper.GetString("namespace"),
 	}
 
 }

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -91,6 +91,12 @@ func init() {
 		false,
 		"When true, includes node summary metrics in metric collection. Default: False",
 	)
+    kubernetesCmd.PersistentFlags().StringVar(
+        &config.Namespace,
+        "namespace",
+        "",
+        "Kubernetes Namespace that the Agent is Running In",
+    )
 
 	//nolint gas
 	_ = viper.BindPFlag("api_key", kubernetesCmd.PersistentFlags().Lookup("api_key"))
@@ -104,6 +110,7 @@ func init() {
 	_ = viper.BindPFlag("outbound_proxy_insecure", kubernetesCmd.PersistentFlags().Lookup("outbound_proxy_insecure"))
 	_ = viper.BindPFlag("insecure", kubernetesCmd.PersistentFlags().Lookup("insecure"))
 	_ = viper.BindPFlag("retrieve_node_summaries", kubernetesCmd.PersistentFlags().Lookup("retrieve_node_summaries"))
+    _ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
 
 	viper.SetEnvPrefix("cloudability")
 	viper.AutomaticEnv()

--- a/kubernetes/heapster.go
+++ b/kubernetes/heapster.go
@@ -122,19 +122,18 @@ func ensureValidHeapster(config KubeAgentConfig) (KubeAgentConfig, error) {
 
 	client := &config.HTTPClient
 	var err error
-	namespace := "cloudability"
 
 	// if Heapster is found in the cluster, test to make sure we can connect to it
 	// or launch an instance in the cloudability namespace. Make sure and close the returned response body.
 	if config.HeapsterURL != "" {
-		return validateHeapster(config, client, namespace)
+		return validateHeapster(config, client, config.Namespace)
 	}
-	log.Printf("Could not find heapster running in the cluster, launching a copy in the %s namespace.", namespace)
+	log.Printf("Could not find heapster running in the cluster, launching a copy in the %s namespace.", config.Namespace)
 
-	config.HeapsterURL, err = launchHeapster(config.Clientset, config.UseInClusterConfig, namespace)
+	config.HeapsterURL, err = launchHeapster(config.Clientset, config.UseInClusterConfig, config.Namespace)
 
 	if err != nil {
-		return config, fmt.Errorf("Error launching heapster in the %s namespace: %+v", err, namespace)
+		return config, fmt.Errorf("Error launching heapster in the %s namespace: %+v", err, config.Namespace)
 	}
 	innerTest, _, err := util.TestHTTPConnection(
 		client, config.HeapsterURL, http.MethodGet, config.BearerToken, retryCount, true)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -387,6 +387,9 @@ func createClusterConfig(config KubeAgentConfig) (KubeAgentConfig, error) {
 	config.Key = thisConfig.KeyFile
 	config.TLSClientConfig.CAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	config.BearerToken = thisConfig.BearerToken
+	if config.Namespace == "" {
+		config.Namespace = "cloudability"
+	}
 
 	config.Clientset, err = kubernetes.NewForConfig(thisConfig)
 	return config, err

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -38,8 +38,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-const namespace string = "cloudability"
-
 //ClusterVersion contains a concatenated version number as well as the k8s version discovery info
 type ClusterVersion struct {
 	version     float64
@@ -77,6 +75,7 @@ type KubeAgentConfig struct {
 	InClusterClient       raw.Client
 	msExportDirectory     *os.File
 	TLSClientConfig       rest.TLSClientConfig
+	Namespace             string
 }
 
 const uploadInterval time.Duration = 10
@@ -93,7 +92,8 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 			"Poll interval:\t%v\n"+
 			"Outbound Proxy:\t%v\n"+
 			"Outbound Proxy Insecure:\t%v\n"+
-			"Insecure:\t%v\n",
+			"Insecure:\t%v\n"+
+			"Namespace:\t%v\n",
 		config.APIKey,
 		config.ClusterName,
 		config.HeapsterOverrideURL,
@@ -101,6 +101,7 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 		config.OutboundProxy,
 		config.OutboundProxyInsecure,
 		config.Insecure,
+		config.Namespace,
 	)
 
 	// Create k8s agent
@@ -118,7 +119,7 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 
 	pollChan := time.NewTicker(time.Duration(config.PollInterval) * time.Second)
 
-	err := fetchDiagnostics(kubeAgent.Clientset, kubeAgent.msExportDirectory)
+	err := fetchDiagnostics(kubeAgent.Clientset, config.Namespace, kubeAgent.msExportDirectory)
 
 	if err != nil {
 		log.Printf("Warning non-fatal error: Agent error occurred retrieving runtime diagnostics: %s ", err)
@@ -699,7 +700,7 @@ func getPodLogs(clientset kubernetes.Interface,
 	return err
 }
 
-func fetchDiagnostics(clientset kubernetes.Interface, msExportDirectory *os.File) (err error) {
+func fetchDiagnostics(clientset kubernetes.Interface, namespace string, msExportDirectory *os.File) (err error) {
 
 	pods, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -126,6 +126,23 @@ func TestUpdateConfigWithOverrideURLs(t *testing.T) {
 
 }
 
+func TestUpdateConfigWithOverrideNamespace(t *testing.T) {
+	t.Parallel()
+
+	config := KubeAgentConfig{
+		APIKey:       "1234-456-789",
+		PollInterval: 600,
+		Insecure:     false,
+        Namespace:    "testing-namespace",
+	}
+	t.Run("ensure that namespace is set correctly", func(t *testing.T) {
+		config, _ := createClusterConfig(config)
+		if config.Namespace != "testing-namespace" {
+			t.Errorf("Expected Namespace to be \"testing-namespace\" but received \"%v\" ", config.Namespace)
+		}
+	})
+}
+
 func TestCreateAgentStatusMetric(t *testing.T) {
 
 	AgentStartTime := time.Now()

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -133,7 +133,7 @@ func TestUpdateConfigWithOverrideNamespace(t *testing.T) {
 		APIKey:       "1234-456-789",
 		PollInterval: 600,
 		Insecure:     false,
-        Namespace:    "testing-namespace",
+		Namespace:    "testing-namespace",
 	}
 	t.Run("ensure that namespace is set correctly", func(t *testing.T) {
 		config, _ := createClusterConfig(config)


### PR DESCRIPTION
#### What does this PR do?

Adds an option to allow you to specify the namespace which the metrics-agent will run in.

#### Where should the reviewer start?
Try deploying to a namespace other than `cloudability` and setting the `--namespace` flag accordingly

#### How should this be manually tested?

`metrics-agent kubernetes --namespace=some-namespace`

#### Any background context you want to provide?

https://github.com/cloudability/metrics-agent/issues/18

#### What picture best describes this PR (optional but encouraged)?

![image](https://user-images.githubusercontent.com/1235844/46422345-0d464e80-c72c-11e8-8b65-554893cce53b.png)

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)