### PR TITLE
Agent preperation for Heapster depreciation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The metrics-agent collects allocation metrics from a container orchestration sys
 
 ## Kubernetes
 
-By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and [Heapster](https://github.com/kubernetes/heapster).  The agent will attempt to connect to heapster, and if unable to communicate with it, the agent will attempt to launch Heapster as a service in the cloudability namespace. An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml). 
+By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and directly from each node in the cluster it is running in. Additionally it will pull metrics from [Heapster](https://github.com/kubernetes/heapster) if found running in the kube-system anmespace cluster.  An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml). 
 
 ### Configuration Options
 
@@ -21,7 +21,7 @@ By default, the agent runs in a namespace named "cloudability" (see options belo
 | CLOUDABILITY_OUTBOUND_PROXY_AUTH        | Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password |
 | CLOUDABILITY_OUTBOUND_PROXY_INSECURE    | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
 | CLOUDABILITY_INSECURE                   | Optional: When true, does not verify certificates when making TLS connections. Default: False|
-| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. Default: False|
+| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Note: when false if heapster is not accessable in the kube-system namespace the agent will launch Heapster in the same namespace as the agent, Default: True|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The metrics-agent collects allocation metrics from a container orchestration sys
 
 ## Kubernetes
 
-By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and directly from each node in the cluster it is running in. Additionally it will pull metrics from [Heapster](https://github.com/kubernetes/heapster) if found running in the kube-system anmespace cluster.  An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml). 
+By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and directly from each node in the cluster it is running in. Additionally it will pull metrics from [Heapster](https://github.com/kubernetes/heapster) if found running in the kube-system namespace cluster.  An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml).
 
 ### Configuration Options
 

--- a/client/client.go
+++ b/client/client.go
@@ -2,11 +2,6 @@ package client
 
 import (
 	"bytes"
-	"net/url"
-	"strings"
-
-	// nolint gas
-	"crypto/md5"
 	"crypto/tls"
 	"encoding/base64"
 	"encoding/json"
@@ -19,15 +14,20 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cloudability/metrics-agent/measurement"
 	"github.com/cloudability/metrics-agent/util"
 	"github.com/cloudability/metrics-agent/version"
 )
+
+//nolint gosec
+import "crypto/md5"
 
 const defaultBaseURL = "https://metrics-collector.cloudability.com"
 const defaultTimeout = 1 * time.Minute

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	kubernetes "github.com/cloudability/metrics-agent/kubernetes"
 	util "github.com/cloudability/metrics-agent/util"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -87,8 +87,8 @@ func init() {
 	kubernetesCmd.PersistentFlags().BoolVar(
 		&config.RetrieveNodeSummaries,
 		"retrieve_node_summaries",
-		false,
-		"When true, includes node summary metrics in metric collection. Default: False",
+		true,
+		"When true, includes node summary metrics in metric collection. Default: True",
 	)
 	kubernetesCmd.PersistentFlags().StringVar(
 		&config.Namespace,
@@ -123,6 +123,7 @@ func init() {
 	config = kubernetes.KubeAgentConfig{
 		APIKey:                viper.GetString("api_key"),
 		ClusterName:           viper.GetString("cluster_name"),
+		CollectHeapsterExport: true,
 		HeapsterOverrideURL:   viper.GetString("heapster_override_url"),
 		PollInterval:          viper.GetInt("poll_interval"),
 		OutboundProxy:         viper.GetString("outbound_proxy"),

--- a/deploy/kubernetes/cloudability-metrics-agent.yaml
+++ b/deploy/kubernetes/cloudability-metrics-agent.yaml
@@ -44,3 +44,4 @@ spec:
               value: "NNNNNNNNN"
             - name: CLOUDABILITY_POLL_INTERVAL
               value: "180"
+

--- a/deploy/kubernetes/cloudability-metrics-agent.yaml
+++ b/deploy/kubernetes/cloudability-metrics-agent.yaml
@@ -44,4 +44,3 @@ spec:
               value: "NNNNNNNNN"
             - name: CLOUDABILITY_POLL_INTERVAL
               value: "180"
-

--- a/kubernetes/heapster.go
+++ b/kubernetes/heapster.go
@@ -98,7 +98,6 @@ func getHeapsterURL(clientset kubernetes.Interface, clusterHostURL string) (URL 
 		if service.Name == "heapster" && service.Namespace == "cloudability" {
 			URL.Host = "http://heapster.cloudability:8082"
 			URL.Path = "/api/v1/metric-export"
-			// log.Printf("Found Heapster service running in the cloudability namespace at:  %v%v", URL.Host, URL.Path)
 			return URL, nil
 		} else if service.Name == "heapster" {
 			URL.Host = clusterHostURL
@@ -122,7 +121,8 @@ func ensureValidHeapster(config KubeAgentConfig) (KubeAgentConfig, error) {
 	var err error
 
 	// if Heapster is found in the cluster, test to make sure we can connect to it
-	// or launch an instance in the cloudability namespace. Make sure and close the returned response body.
+	// or if not using node summaries and unable to connect or find heapster in the kube-system namespace
+	// launch an instance of heapster in the cloudability namespace. Make sure and close the returned response body.
 	if config.HeapsterURL != "" {
 		return validateHeapster(config, client, config.Namespace)
 	}

--- a/kubernetes/heapster.go
+++ b/kubernetes/heapster.go
@@ -89,7 +89,6 @@ func getHeapsterURL(clientset kubernetes.Interface, clusterHostURL string) (URL 
 		if strings.Contains(pod.Name, "heapster") {
 			URL.Host = clusterHostURL
 			URL.Path = pod.SelfLink + ":8082/proxy/api/v1/metric-export"
-			log.Printf("Found Heapster at:  %v%v", URL.Host, URL.Path)
 		}
 	}
 
@@ -99,7 +98,7 @@ func getHeapsterURL(clientset kubernetes.Interface, clusterHostURL string) (URL 
 		if service.Name == "heapster" && service.Namespace == "cloudability" {
 			URL.Host = "http://heapster.cloudability:8082"
 			URL.Path = "/api/v1/metric-export"
-			log.Printf("Found Heapster service running in the cloudability namespace at:  %v%v", URL.Host, URL.Path)
+			// log.Printf("Found Heapster service running in the cloudability namespace at:  %v%v", URL.Host, URL.Path)
 			return URL, nil
 		} else if service.Name == "heapster" {
 			URL.Host = clusterHostURL
@@ -109,7 +108,6 @@ func getHeapsterURL(clientset kubernetes.Interface, clusterHostURL string) (URL 
 			} else {
 				URL.Path = service.SelfLink + "/proxy/api/v1/metric-export"
 			}
-			log.Printf("Found Heapster at:  %v%v", URL.Host, URL.Path)
 		}
 	}
 
@@ -128,17 +126,19 @@ func ensureValidHeapster(config KubeAgentConfig) (KubeAgentConfig, error) {
 	if config.HeapsterURL != "" {
 		return validateHeapster(config, client, config.Namespace)
 	}
-	log.Printf("Could not find heapster running in the cluster, launching a copy in the %s namespace.", config.Namespace)
+	if !config.RetrieveNodeSummaries {
+		log.Printf("Could not find heapster running in the cluster, launching a copy in the %s namespace.", config.Namespace)
 
-	config.HeapsterURL, err = launchHeapster(config.Clientset, config.UseInClusterConfig, config.Namespace)
+		config.HeapsterURL, err = launchHeapster(config.Clientset, config.UseInClusterConfig, config.Namespace)
 
-	if err != nil {
-		return config, fmt.Errorf("Error launching heapster in the %s namespace: %+v", err, config.Namespace)
-	}
-	innerTest, _, err := util.TestHTTPConnection(
-		client, config.HeapsterURL, http.MethodGet, config.BearerToken, retryCount, true)
-	if innerTest || err == nil {
-		log.Printf("Connected to heapster at: %v", config.HeapsterURL)
+		if err != nil {
+			return config, fmt.Errorf("Error launching heapster in the %s namespace: %+v", err, config.Namespace)
+		}
+		innerTest, _, err := util.TestHTTPConnection(
+			client, config.HeapsterURL, http.MethodGet, config.BearerToken, retryCount, true)
+		if innerTest || err == nil {
+			log.Printf("Connected to heapster at: %v", config.HeapsterURL)
+		}
 	}
 
 	return config, err

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -7,12 +7,11 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
-
-	"path/filepath"
-	"strings"
 
 	"github.com/cloudability/metrics-agent/retrieval/raw"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -47,7 +47,7 @@ func TestUpdateConfigurationForServices(t *testing.T) {
 	t.Run("ensure that an updated agentConfig with services if running is returned", func(t *testing.T) {
 		selfLink := "http://localhost"
 		servicePort := 8080
-		clientSet := fake.NewSimpleClientset(&v1.Service{
+		config.Clientset = fake.NewSimpleClientset(&v1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "heapster",
 				Namespace: v1.NamespaceDefault,
@@ -65,7 +65,7 @@ func TestUpdateConfigurationForServices(t *testing.T) {
 			},
 		})
 
-		_, err := updateConfigurationForServices(clientSet, config)
+		_, err := updateConfigurationForServices(config)
 		if err != nil {
 			t.Errorf("Error getting services %v ", err)
 		}
@@ -74,7 +74,7 @@ func TestUpdateConfigurationForServices(t *testing.T) {
 	t.Run("ensure that an updated agentConfig with services if running without defined serviceport is returned",
 		func(t *testing.T) {
 			selfLink := "http://localhost"
-			clientSet := fake.NewSimpleClientset(&v1.Service{
+			config.Clientset = fake.NewSimpleClientset(&v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "heapster",
 					Namespace: v1.NamespaceDefault,
@@ -85,7 +85,7 @@ func TestUpdateConfigurationForServices(t *testing.T) {
 				},
 			})
 
-			_, err := updateConfigurationForServices(clientSet, config)
+			_, err := updateConfigurationForServices(config)
 			if err != nil {
 				t.Errorf("Error getting services %v ", err)
 			}

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -83,13 +83,13 @@ func downloadNodeData(prefix string,
 				return nil, fmt.Errorf("error: %s", err)
 			}
 			nodeStatSum := fmt.Sprintf("https://%s:%v/stats/summary", ip, int64(port))
-			_, err = config.NodeClient.GetRawEndPoint(http.MethodGet, prefix+"-summary-"+n.Name, workDir, nodeStatSum, nil)
+			_, err = config.NodeClient.GetRawEndPoint(http.MethodGet, prefix+"-summary-"+n.Name, workDir, nodeStatSum, nil, true)
 			if err != nil {
 				failedNodeList[n.Name] = err
 			}
 			containerStats := fmt.Sprintf("https://%s:%v/stats/container/", ip, int64(port))
 			_, err = config.NodeClient.GetRawEndPoint(
-				http.MethodPost, prefix+"-container-"+n.Name, workDir, containerStats, containersRequest)
+				http.MethodPost, prefix+"-container-"+n.Name, workDir, containerStats, containersRequest, true)
 			if err != nil {
 				failedNodeList[n.Name] = err
 			}
@@ -98,13 +98,14 @@ func downloadNodeData(prefix string,
 
 		// retrieve node summary via kube-proxy
 		nodeStatSum := fmt.Sprintf("%s/api/v1/nodes/%s:10255/proxy/stats/summary", config.ClusterHostURL, n.Name)
-		_, err = config.InClusterClient.GetRawEndPoint(http.MethodGet, prefix+"-summary-"+n.Name, workDir, nodeStatSum, nil)
+		_, err = config.InClusterClient.GetRawEndPoint(
+			http.MethodGet, prefix+"-summary-"+n.Name, workDir, nodeStatSum, nil, true)
 		if err != nil {
 			failedNodeList[n.Name] = err
 		}
 		containerStats := fmt.Sprintf("%s/api/v1/nodes/%s:10255/proxy/stats/container/", config.ClusterHostURL, n.Name)
 		_, err = config.InClusterClient.GetRawEndPoint(
-			http.MethodPost, prefix+"-container-"+n.Name, workDir, containerStats, containersRequest)
+			http.MethodPost, prefix+"-container-"+n.Name, workDir, containerStats, containersRequest, true)
 		if err != nil {
 			failedNodeList[n.Name] = err
 		}

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cloudability/metrics-agent/retrieval/raw"
 	"github.com/cloudability/metrics-agent/util"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/pkg/api/v1"

--- a/retrieval/k8s/k8s_stats.go
+++ b/retrieval/k8s/k8s_stats.go
@@ -15,7 +15,7 @@ func GetK8sMetrics(clusterHostURL string, clusterVersion float64, workDir *os.Fi
 
 	// get v1 sources
 	for _, v1s := range v1Sources {
-		_, err := rawClient.GetRawEndPoint(http.MethodGet, v1s, workDir, clusterHostURL+"/api/v1/"+v1s, nil)
+		_, err := rawClient.GetRawEndPoint(http.MethodGet, v1s, workDir, clusterHostURL+"/api/v1/"+v1s, nil, true)
 		if err != nil {
 			log.Printf("Error retrieving "+v1s+" metric endpoint: %s", err)
 			return err
@@ -25,7 +25,7 @@ func GetK8sMetrics(clusterHostURL string, clusterVersion float64, workDir *os.Fi
 	// get v1beta1 sources
 	for _, v1b1s := range v1beta1Sources {
 		_, err := rawClient.GetRawEndPoint(
-			http.MethodGet, v1b1s, workDir, clusterHostURL+"/apis/extensions/v1beta1/"+v1b1s, nil)
+			http.MethodGet, v1b1s, workDir, clusterHostURL+"/apis/extensions/v1beta1/"+v1b1s, nil, true)
 		if err != nil {
 			log.Printf("Error retrieving "+v1b1s+" metric endpoint: %s", err)
 			return err
@@ -33,7 +33,7 @@ func GetK8sMetrics(clusterHostURL string, clusterVersion float64, workDir *os.Fi
 	}
 
 	// get jobs
-	_, err = rawClient.GetRawEndPoint(http.MethodGet, "jobs", workDir, clusterHostURL+"/apis/batch/v1/jobs", nil)
+	_, err = rawClient.GetRawEndPoint(http.MethodGet, "jobs", workDir, clusterHostURL+"/apis/batch/v1/jobs", nil, true)
 	if err != nil {
 		log.Printf("Error retrieving jobs metric endpoint: %s", err)
 		return err

--- a/retrieval/raw/raw_endpoint.go
+++ b/retrieval/raw/raw_endpoint.go
@@ -52,7 +52,7 @@ func (c *Client) createRequest(method, url string, body io.Reader) (*http.Reques
 //GetRawEndPoint retrives the body of HTTP response from a given method ,
 // sourcename, working directory, URL, and request body
 func (c *Client) GetRawEndPoint(method, sourceName string,
-	workDir *os.File, URL string, body []byte) (rawRespFile *os.File, err error) {
+	workDir *os.File, URL string, body []byte, verbose bool) (rawRespFile *os.File, err error) {
 
 	attempts := c.retries + 1
 	b := bytes.NewBuffer(body)
@@ -65,7 +65,9 @@ func (c *Client) GetRawEndPoint(method, sourceName string,
 		if err == nil {
 			return rawRespFile, nil
 		}
-		log.Printf("%v URL: %s retrying: %v", err, URL, i+1)
+		if verbose {
+			log.Printf("%v URL: %s retrying: %v", err, URL, i+1)
+		}
 	}
 	return nil, err
 }

--- a/retrieval/raw/raw_endpoint_test.go
+++ b/retrieval/raw/raw_endpoint_test.go
@@ -34,7 +34,7 @@ func TestGetRawEndPoint(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		testFile, err := client.GetRawEndPoint(http.MethodGet, "heapster", workingDir, ts.URL, nil)
+		testFile, err := client.GetRawEndPoint(http.MethodGet, "heapster", workingDir, ts.URL, nil, true)
 		if err != nil {
 			t.Error(err)
 		}
@@ -69,7 +69,7 @@ func TestGetRawEndPoint(t *testing.T) {
 		}))
 		defer ts.Close()
 
-		_, err := client.GetRawEndPoint(http.MethodGet, "heapster", workingDir, ts.URL, nil)
+		_, err := client.GetRawEndPoint(http.MethodGet, "heapster", workingDir, ts.URL, nil, true)
 		if err == nil {
 			t.Error("Server returned invalid response code but function did not raise error")
 		}
@@ -90,7 +90,7 @@ func TestGetRawEndPoint(t *testing.T) {
 		wd, _ := ioutil.TempDir("", "raw_endpoint_test")
 		workingDir, _ := os.Open(wd)
 
-		_, err := client.GetRawEndPoint(http.MethodGet, "heapster", workingDir, "http://localhost:1234", nil)
+		_, err := client.GetRawEndPoint(http.MethodGet, "heapster", workingDir, "http://localhost:1234", nil, true)
 		if err == nil {
 			t.Error("Unable to to connect to server but function did not raise error")
 		}

--- a/util/util.go
+++ b/util/util.go
@@ -15,10 +15,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/spf13/viper"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "0.1.1"
+var VERSION = "0.1.2"


### PR DESCRIPTION
#### What does this PR do?

- set collect node summaries to true by default
- adds verbose flag to getrawexport function
- simplifies agent log messages
- updates agent behavior to not launch heapster in cloudability namespace when collect node summaries set to true (Default)
- updated agent to not raise error if issues occur collecting heapster data when collect node summaries set to true

#### Where should the reviewer start?
https://github.com/cloudability/metrics-agent/compare/master...DavidXArnold:dontLaunchHeapster?expand=1#diff-200190c419427e5b1b31ad50f5b3dabbR90

#### Any background context you want to provide?
In preparation of deprecating the use of heapster as the source of metrics in a Kubernetes cluster, this PR updates the agent to pull metrics directly from the nodes and pull heapster metrics if present. With this chance, the agent will no longer launch heapster in the Cloudability namespace by default.

#### What picture best describes this PR (optional but encouraged)?
![](https://androidexample365.com/content/images/2017/08/spinningwheelc.gif)

#### What are the relevant Github Issues?
#19 

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)