### PR TITLE
default RETRIEVE_NODE_SUMMARIES to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ By default, the agent runs in a namespace named "cloudability" (see options belo
 | CLOUDABILITY_OUTBOUND_PROXY_AUTH        | Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password |
 | CLOUDABILITY_OUTBOUND_PROXY_INSECURE    | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
 | CLOUDABILITY_INSECURE                   | Optional: When true, does not verify certificates when making TLS connections. Default: False|
-| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Note: when false if heapster is not accessable in the kube-system namespace the agent will launch Heapster in the same namespace as the agent, Default: True|
+| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Note: when false if heapster is not accessable in the kube-system namespace the agent will launch Heapster in the same namespace as the agent, Default: False|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 
 ```sh

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -87,7 +87,7 @@ func init() {
 	kubernetesCmd.PersistentFlags().BoolVar(
 		&config.RetrieveNodeSummaries,
 		"retrieve_node_summaries",
-		true,
+		false,
 		"When true, includes node summary metrics in metric collection. Default: True",
 	)
 	kubernetesCmd.PersistentFlags().StringVar(

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "0.1.2"
+var VERSION = "0.1.3"


### PR DESCRIPTION
#### What does this PR do?
- sets the default value for RETRIEVE_NODE_SUMMARIES to false

#### Where should the reviewer start?
https://github.com/cloudability/metrics-agent/compare/master...DavidXArnold:setSummaryDefault?expand=1#diff-200190c419427e5b1b31ad50f5b3dabbR90

#### Any background context you want to provide?
RETRIEVE_NODE_SUMMARIES should be false until heapster depreciation is fully implemented.

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)