### PR TITLE
Collect heapster even when node_summaries set to true

### DIFF
--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -198,12 +198,13 @@ func (ka KubeAgentConfig) collectMetrics(
 	}
 
 	if config.RetrieveNodeSummaries {
-
 		err = retrieveNodeSummaries(config, msd, metricSampleDir, nodeSource)
 		if err != nil {
 			log.Printf("Warning: %s", err)
 		}
-	} else {
+	}
+
+	if config.CollectHeapsterExport {
 		// get raw Heapster metric sample
 		hme, err := config.InClusterClient.GetRawEndPoint(
 			http.MethodGet, "heapster-metrics-export", metricSampleDir, config.HeapsterURL, nil, true)

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "0.1.3"
+var VERSION = "0.1.4"


### PR DESCRIPTION
#### What does this PR do?
Collects heapster metrics export even when preferNodeSummaries is true.

#### Where should the reviewer start?
`kubernetes/kubernetes.go`

#### How should this be manually tested?
Ensure heapster files are being uploaded to collections.

#### Any background context you want to provide?
This is affecting our ability to test differences between heapster/summaries.

#### What picture best describes this PR (optional but encouraged)?
https://media.giphy.com/media/PsgmBGhbIC85W/giphy.gif

#### What are the relevant Github Issues?
N/A

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)