### PR TITLE
fix version container tag 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,3 +2,4 @@
 *  @DavidXArnold
 *  @housejester
 *  @mollylogue
+*  @mnorbury

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ PKG := github.com/cloudability/metrics-agent
 # This version-strategy uses git tags to set the version string
 VERSION := $(shell git describe --tags --always --dirty)
 
+RELEASE-VERSION := $(shell sed -nE 's/^var[[:space:]]VERSION[[:space:]]=[[:space:]]"([^"]+)".*/\1/p' version/version.go)
+
 # If this session isn't interactive, then we don't want to allocate a
 # TTY, which would fail, but if it is interactive, we do want to attach
 # so that the user can send e.g. ^C through.
@@ -59,9 +61,9 @@ deploy-local: container-local
 
 dockerhub-push:
 	docker tag $(PREFIX)/metrics-agent:$(VERSION) cloudability/metrics-agent:latest
-	docker tag $(PREFIX)/metrics-agent:$(VERSION) cloudability/metrics-agent:$(VERSION)
+	docker tag $(PREFIX)/metrics-agent:$(VERSION) cloudability/metrics-agent:$(RELEASE-VERSION)
 	docker push cloudability/metrics-agent:latest
-	docker push cloudability/metrics-agent:$(VERSION)
+	docker push cloudability/metrics-agent:$(RELEASE-VERSION)
 	
 fmt:
 	goreturns -w .
@@ -79,5 +81,8 @@ check: fmt lint test
 
 version:
 	@echo $(VERSION)
+
+release-version:
+	@echo $(RELEASE-VERSION)
 
 .PHONY: test version


### PR DESCRIPTION
#### What does this PR do?
- fixes the container version tag during build step
- adds mnorbury as code owner

#### Where should the reviewer start?
https://github.com/cloudability/metrics-agent/compare/master...DavidXArnold:tagVersion?expand=1#diff-b67911656ef5d18c4ae36cb6741b7965R21

#### How should this be manually tested?
`make release-version`

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)