### PR TITLE
Increase circleci timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
       - run: 
           name: Lint
           command: make lint
+          no_output_timeout: 20m
 
       - run:
           name: Run Tests


### PR DESCRIPTION
#### What does this PR do?

Increase the CircleCI timeout on the lint step to 20m.

#### Where should the reviewer start?

CircleCI [config](https://github.com/cloudability/metrics-agent/compare/master...mn-con-651#diff-1d37e48f9ceff6d8030570cd36286a61R33) file.

#### How should this be manually tested?

N/A

#### Any background context you want to provide?

The lint step often times out at 10 minutes.

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)