### PR TITLE
exit rather than warn if unable to retrieve node summaries

### DIFF
--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -553,8 +553,7 @@ func ensureMetricServicesAvailable(config KubeAgentConfig) (KubeAgentConfig, err
 	if config.RetrieveNodeSummaries {
 		config, err = ensureNodeSource(config)
 		if err != nil {
-			log.Printf("Warning non-fatal error: Agent error occurred retrieving node source metrics: %s ", err)
-			log.Printf("For more information see: %v", kbURL)
+			return config, fmt.Errorf("unable to retrieve node summaries: %s", err)
 		}
 	}
 	if config.CollectHeapsterExport {

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -135,7 +135,7 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 		}
 
 		var err error
-		config, err = ensureMetricServicesAvailable(config)
+		_, err = ensureMetricServicesAvailable(config)
 		if err != nil {
 			t.Errorf("Unexpected error fetching node summaries: %s", err)
 		}

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -14,7 +14,7 @@ import (
 	"github.com/kubernetes/kubernetes/staging/src/k8s.io/client-go/util/retry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	v1 "k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/api/v1"
 )
 
 // NodeSource is an interface to get a list of Nodes
@@ -77,7 +77,7 @@ func downloadNodeData(prefix string,
 	containersRequest, err := buildContainersRequest()
 
 	if err != nil {
-		return nil, fmt.Errorf("Error occurred requesting container statistics: %v", err)
+		return nil, fmt.Errorf("error occurred requesting container statistics: %v", err)
 	}
 
 	for _, n := range nodes.Items {
@@ -185,7 +185,7 @@ func ensureNodeSource(config KubeAgentConfig) (KubeAgentConfig, error) {
 
 	config.nodeRetrievalMethod = "unreachable"
 	config.RetrieveNodeSummaries = false
-	return config, fmt.Errorf("Unable to retrieve node metrics. Please verify RBAC roles: %v", err)
+	return config, fmt.Errorf("unable to retrieve node metrics. Please verify RBAC roles: %v", err)
 }
 
 func retrieveNodeSummaries(

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.0.3"
+var VERSION = "1.0.4"


### PR DESCRIPTION
#### What does this PR do?
Righty now we only log a warning if we're unable to fetch the node summaries. Instead this should be a fatal error. 

#### Where should the reviewer start?

#### How should this be manually tested?
Make deploy-local and verify that the we exit if cannot connect to nodes

#### Any background context you want to provide? 
Found a bug that resulted in a bunch of empty metrics samples. A fatal error would've been more appropriate there. 

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)