### PR TITLE
Crashg Loop Fix 

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.0.4"
+var VERSION = "1.0.5"


### PR DESCRIPTION
#### What does this PR do?
- addresses crash loop that was introduced in v1.0.4 for k8s clusters when Heapster was in use but node summaries were unavailable due to RBAC restrictions or other conditions.

#### Where should the reviewer start?
- kubernetes/kubernetes.go

#### How should this be manually tested?
`make deploy-local`

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [x] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)