### PR TITLE
CON-1005 add option to configure what directory we will write metrics to

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, the agent runs in a namespace named "cloudability" (see options belo
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 | CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
 | CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
-| CLOUDABILITY_SCRATCH_DIR                | Optional: Directory metrics will be written to. Default: `/tmp`|
+| CLOUDABILITY_SCRATCH_DIR                | Optional: Directory metrics will be written to. Must assure that the user agent UID 1000 has read/write access to the folder. Default: `/tmp`|
 
 ```sh
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ By default, the agent runs in a namespace named "cloudability" (see options belo
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 | CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
 | CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
-| CLOUDABILITY_SCRATCH_DIR                | Optional: Directory metrics will be written to. Must assure that the user agent UID 1000 has read/write access to the folder. Default: `/tmp`|
+| CLOUDABILITY_SCRATCH_DIR                | Optional: Temporary directory that metrics will be written to. If set, must assure that the directory exists and that the user agent UID 1000 has read/write access to the folder. Default: `/tmp`|
 
 ```sh
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ By default, the agent runs in a namespace named "cloudability" (see options belo
 | CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
 | CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
-| CLOUDABILITY_LOG_FORMAT    | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
+| CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
 | CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
+| CLOUDABILITY_SCRATCH_DIR                | Optional: Directory metrics will be written to. Default: `/tmp`|
 
 ```sh
 

--- a/client/client.go
+++ b/client/client.go
@@ -22,7 +22,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"crypto/md5"
+	"crypto/md5" //nolint gosec
 
 	"github.com/cloudability/metrics-agent/measurement"
 	"github.com/cloudability/metrics-agent/util"

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -108,6 +108,12 @@ func init() {
 		"cloudability",
 		"Kubernetes Namespace that the Agent is Running In",
 	)
+	kubernetesCmd.PersistentFlags().StringVar(
+		&config.ScratchDir,
+		"scratch_dir",
+		"/tmp",
+		"Directory metrics will be written to",
+	)
 
 	//nolint gas
 	_ = viper.BindPFlag("api_key", kubernetesCmd.PersistentFlags().Lookup("api_key"))
@@ -123,6 +129,7 @@ func init() {
 	_ = viper.BindPFlag("retrieve_node_summaries", kubernetesCmd.PersistentFlags().Lookup("retrieve_node_summaries"))
 	_ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
 	_ = viper.BindPFlag("collect_heapster_export", kubernetesCmd.PersistentFlags().Lookup("collect_heapster_export"))
+	_ = viper.BindPFlag("scratch_dir", kubernetesCmd.PersistentFlags().Lookup("scratch_dir"))
 
 	viper.SetEnvPrefix("cloudability")
 	viper.AutomaticEnv()
@@ -143,6 +150,7 @@ func init() {
 		Key:                   viper.GetString("key_file"),
 		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
 		Namespace:             viper.GetString("namespace"),
+		ScratchDir:            viper.GetString("scratch_dir"),
 	}
 
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,6 +39,7 @@ func init() {
 	// set version flag
 	RootCmd.Version = cldyVersion.VERSION
 
+	//nolint gosec
 	_ = viper.BindPFlag("log_level", RootCmd.PersistentFlags().Lookup("log_level"))
 	_ = viper.BindPFlag("log_format", RootCmd.PersistentFlags().Lookup("log_format"))
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -75,6 +75,7 @@ type KubeAgentConfig struct {
 	msExportDirectory     *os.File
 	TLSClientConfig       rest.TLSClientConfig
 	Namespace             string
+	ScratchDir            string
 }
 
 const uploadInterval time.Duration = 10
@@ -179,14 +180,19 @@ func newKubeAgent(config KubeAgentConfig) KubeAgentConfig {
 		log.Fatal(err)
 	}
 
+	// setup directory for writing metrics to
+	err = util.SetupScratchDir(config.ScratchDir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	//Create metric sample working directory
-	config.msExportDirectory, err = util.CreateMSWorkingDirectory(config.clusterUID)
+	config.msExportDirectory, err = util.CreateMSWorkingDirectory(config.clusterUID, config.ScratchDir)
 	if err != nil {
 		log.Fatalf("cloudability metric agent is unable to create a temporary working directory: %v", err)
 	}
 
 	return config
-
 }
 
 func (ka KubeAgentConfig) collectMetrics(

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -127,7 +127,7 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 		case <-sendChan.C:
 
 			//Bundle raw metrics
-			metricSample, err := util.CreateMetricSample(*kubeAgent.msExportDirectory, kubeAgent.clusterUID, true)
+			metricSample, err := util.CreateMetricSample(*kubeAgent.msExportDirectory, kubeAgent.clusterUID, true, kubeAgent.ScratchDir)
 			if err != nil {
 				log.Fatalf("Error creating metric sample: %s", err)
 			}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -127,7 +127,8 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 		case <-sendChan.C:
 
 			//Bundle raw metrics
-			metricSample, err := util.CreateMetricSample(*kubeAgent.msExportDirectory, kubeAgent.clusterUID, true, kubeAgent.ScratchDir)
+			metricSample, err := util.CreateMetricSample(
+				*kubeAgent.msExportDirectory, kubeAgent.clusterUID, true, kubeAgent.ScratchDir)
 			if err != nil {
 				log.Fatalf("Error creating metric sample: %s", err)
 			}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -181,7 +181,7 @@ func newKubeAgent(config KubeAgentConfig) KubeAgentConfig {
 	}
 
 	// setup directory for writing metrics to
-	err = util.SetupScratchDir(config.ScratchDir)
+	err = util.ValidateScratchDir(config.ScratchDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -328,9 +328,9 @@ func SetupLogger() (err error) {
 	return nil
 }
 
-func SetupScratchDir(scratchDir string) error {
+func ValidateScratchDir(scratchDir string) error {
 	if _, err := os.Stat(scratchDir); os.IsNotExist(err) {
-		return os.MkdirAll(scratchDir, os.ModeDir)
+		return fmt.Errorf("There was a problem validating provided scratch directory: %v", err)
 	}
 
 	return nil

--- a/util/util.go
+++ b/util/util.go
@@ -328,6 +328,7 @@ func SetupLogger() (err error) {
 	return nil
 }
 
+//ValidateScratchDir validates whether or not the scratch directory exists or not
 func ValidateScratchDir(scratchDir string) error {
 	if _, err := os.Stat(scratchDir); os.IsNotExist(err) {
 		return fmt.Errorf("There was a problem validating provided scratch directory: %v", err)

--- a/util/util.go
+++ b/util/util.go
@@ -200,9 +200,9 @@ func getExportFilename(uid string) string {
 }
 
 //CreateMSWorkingDirectory takes a given prefix and returns a metric sample working directory
-func CreateMSWorkingDirectory(uid string) (*os.File, error) {
+func CreateMSWorkingDirectory(uid string, scratchDir string) (*os.File, error) {
 	//create metric sample directory
-	td, err := ioutil.TempDir("", "cldy-metrics")
+	td, err := ioutil.TempDir(scratchDir, "cldy-metrics")
 	if err != nil {
 		log.Errorf("Unable to create temporary directory: %v", err)
 		return nil, err
@@ -325,5 +325,13 @@ func SetupLogger() (err error) {
 			PadLevelText:           true,
 		})
 	}
+	return nil
+}
+
+func SetupScratchDir(scratchDir string) error {
+	if _, err := os.Stat(scratchDir); os.IsNotExist(err) {
+		return os.MkdirAll(scratchDir, os.ModeDir)
+	}
+
 	return nil
 }

--- a/util/util.go
+++ b/util/util.go
@@ -86,7 +86,7 @@ func CheckRequiredSettings(requiredArgs []string) error {
 }
 
 //CreateMetricSample creates a metric sample from a given directory removing the source directory if cleanup is true
-func CreateMetricSample(exportDirectory os.File, uid string, cleanUp bool) (*os.File, error) {
+func CreateMetricSample(exportDirectory os.File, uid string, cleanUp bool, scratchDir string) (*os.File, error) {
 
 	ed, err := exportDirectory.Stat()
 	if err != nil || !ed.IsDir() {
@@ -95,7 +95,7 @@ func CreateMetricSample(exportDirectory os.File, uid string, cleanUp bool) (*os.
 	}
 
 	sampleFilename := getExportFilename(uid)
-	destFile, err := os.Create(os.TempDir() + "/" + sampleFilename + ".tgz")
+	destFile, err := os.Create(scratchDir + "/" + sampleFilename + ".tgz")
 
 	if err != nil {
 		log.Errorf("Unable to create metric sample file: %v", err)

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -196,7 +196,7 @@ func TestCreateMetricSample(t *testing.T) {
 
 		if _, err = os.Stat(testDataDirectory); err == nil {
 			sampleDirectory, err = os.Open(testDataDirectory)
-			ms, err := CreateMetricSample(*sampleDirectory, "cluster-id", false)
+			ms, err := CreateMetricSample(*sampleDirectory, "cluster-id", false, os.TempDir())
 			if err != nil {
 				t.Errorf("Error creating agent Status Metric: %v", err)
 			}

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -261,3 +261,23 @@ func TestMatchOneFile(t *testing.T) {
 	_ = os.RemoveAll(dir)
 
 }
+
+func TestValidateScratchDir(t *testing.T) {
+	t.Run("Ensure that an error is returned when directory doesn't exist", func(t *testing.T) {
+		fakeDir := "/fake_dir"
+		err := ValidateScratchDir(fakeDir)
+
+		if err == nil {
+			t.Errorf("Should have raised an error when validating scratch directory that does not exist, error: %v", err)
+		}
+	})
+
+	t.Run("Ensure that no error is returned when it is directory that does exist", func(t *testing.T) {
+		scratchDir := "/tmp"
+		err := ValidateScratchDir(scratchDir)
+
+		if err != nil {
+			t.Errorf("Should not have raised an error when validating scratch directory that does exist, error: %v", err)
+		}
+	})
+}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.0.11"
+var VERSION = "1.0.12"


### PR DESCRIPTION
#### What does this PR do?
add environment variable as well as CLI flag that can be used to set which directory is used for writing metrics
#### Where should the reviewer start?
Make sure that the metrics will be written and read from the passed in directory
#### How should this be manually tested?
I personally had to change Dockerfile to create a new directory with read/write permission and use that as the passed in cloudability_scratch_dir environment variable
#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)