### PR TITLE
upgrade go to v1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     docker:
       # CircleCI Go images available at: https://hub.docker.com/r/circleci/golang/
-      - image: circleci/golang:1.10
+      - image: circleci/golang:1.11
 
     working_directory: /go/src/github.com/cloudability/metrics-agent
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ EXECUTABLES = go dep
 EXEC_CHECK := $(foreach exec,$(EXECUTABLES), \
 	$(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH.")))
 
-GOLANG_VERSION?=1.10
+GOLANG_VERSION?=1.11
 REPO_DIR:=$(shell pwd)
 PREFIX=cloudability
 CLDY_API_KEY=${CLOUDABILITY_API_KEY}

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.0.12"
+var VERSION = "1.0.13"


### PR DESCRIPTION
#### What does this PR do?
Bumps go version from 1.10 to 1.11, this work is in preparation to switch linters and the latest linter requires at least go 1.11
#### Where should the reviewer start?
n/a
#### How should this be manually tested?
have tested the agent on go 1.11 and had no issues
#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [ ] Updated README.md
- [x] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)