### PR TITLE
Jp fargate flag force proxy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,4 +42,4 @@ it keeps history cleaner and it's easier to revert things.
 
 ### Increment the agent version number
 
-Currently the agent version is managed manually in [this file](version.go) please use [Semantic Versioning 2.0.0](https://semver.org/) as your guideline.
+Currently the agent version is managed manually in [this file](version/version.go) please use [Semantic Versioning 2.0.0](https://semver.org/) as your guideline.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ By default, the agent runs in a namespace named "cloudability" (see options belo
 | CLOUDABILITY_OUTBOUND_PROXY_INSECURE    | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
 | CLOUDABILITY_INSECURE                   | Optional: When true, does not verify certificates when making TLS connections. Default: False|
 | CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
+| CLOUDABILITY_FORCE_KUBE_PROXY           | Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False|
 | CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 | CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
@@ -47,6 +48,8 @@ Flags:
       --outbound_proxy string                    Outbound HTTP/HTTPS proxy eg: http://x.x.x.x:8080. Must have a scheme prefix (http:// or https://) - Optional
       --outbound_proxy_auth string               Outbound proxy basic authentication credentials. Must defined in the form username:password - Optional
       --outbound_proxy_insecure                  When true, does not verify TLS certificates when using the outbound proxy. Default: False
+      --retrieve_node_summaries                  When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True
+      --force_kube_proxy                         When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False
       --poll_interval int                        Time, in seconds, to poll the services infrastructure. Default: 180 (default 180)
       --namespace string                         The namespace which the agent runs in. Changing this is not recommended. (default `cloudability`)
 Global Flags:

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -97,6 +97,12 @@ func init() {
 		"When true, includes node summary metrics in metric collection.",
 	)
 	kubernetesCmd.PersistentFlags().BoolVar(
+		&config.ForceKubeProxy,
+		"force_kube_proxy",
+		false,
+		"When true, disables direct node connection and forces proxy use.",
+	)
+	kubernetesCmd.PersistentFlags().BoolVar(
 		&config.CollectHeapsterExport,
 		"collect_heapster_export",
 		true,
@@ -127,6 +133,7 @@ func init() {
 	_ = viper.BindPFlag("outbound_proxy_insecure", kubernetesCmd.PersistentFlags().Lookup("outbound_proxy_insecure"))
 	_ = viper.BindPFlag("insecure", kubernetesCmd.PersistentFlags().Lookup("insecure"))
 	_ = viper.BindPFlag("retrieve_node_summaries", kubernetesCmd.PersistentFlags().Lookup("retrieve_node_summaries"))
+	_ = viper.BindPFlag("force_kube_proxy", kubernetesCmd.PersistentFlags().Lookup("force_kube_proxy"))
 	_ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
 	_ = viper.BindPFlag("collect_heapster_export", kubernetesCmd.PersistentFlags().Lookup("collect_heapster_export"))
 	_ = viper.BindPFlag("scratch_dir", kubernetesCmd.PersistentFlags().Lookup("scratch_dir"))
@@ -149,6 +156,7 @@ func init() {
 		Cert:                  viper.GetString("certificate_file"),
 		Key:                   viper.GetString("key_file"),
 		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
+		ForceKubeProxy:        viper.GetBool("force_kube_proxy"),
 		Namespace:             viper.GetString("namespace"),
 		ScratchDir:            viper.GetString("scratch_dir"),
 	}

--- a/kubernetes/export_test.go
+++ b/kubernetes/export_test.go
@@ -1,4 +1,10 @@
 package kubernetes
 
-var EnsureNodeSource = ensureNodeSource
-var DownloadNodeData = downloadNodeData
+var (
+	IsFargateNode    = isFargateNode
+	EnsureNodeSource = ensureNodeSource
+	DownloadNodeData = downloadNodeData
+	Unreachable      = unreachable
+	Proxy            = proxy
+	Direct           = direct
+)

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -111,7 +111,7 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 			t.Errorf("expected an error for ensureMetricServicesAvailable")
 			return
 		}
-		if config.nodeRetrievalMethod != "unreachable" {
+		if config.nodeRetrievalMethod != Unreachable {
 			t.Errorf("expected nodeRetrievalMethod to be asdf, instead was %s", config.nodeRetrievalMethod)
 		}
 	})
@@ -250,6 +250,7 @@ func TestCollectMetrics(t *testing.T) {
 		Insecure:              true,
 		BearerToken:           "",
 		RetrieveNodeSummaries: true,
+		ForceKubeProxy:        false,
 	}
 
 	ka.InClusterClient = raw.NewClient(ka.HTTPClient, ka.Insecure, ka.BearerToken, 0)

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.0.15"
+var VERSION = "1.1.0"


### PR DESCRIPTION
#### What does this PR do?
Reduce log noise by disallowing direct connection for node metrics collection when Fargate nodes are detected in the cluster. Currently Fargate nodes cannot be queried for metrics directly and the proxy api must be used.

Also allow forcing the use of the kube-proxy (and disabling direct node connect) for all nodes, with a flag or environment variable.

#### Where should the reviewer start?
kubernetes/nodecollection.go:allowDirectConnect is a good place to start. We use this to check what type of connection the subsequent node metrics requests should use.

#### How should this be manually tested?

This can be deployed to a local kube cluster via the Makefile shortcut. Toggle the CLOUDABILITY_FORCE_KUBE_PROXY env var or flag to test forcing the proxy and disabling direct connect for all nodes. 

You can also apply a label that matches how a Fargate node is tagged to your local node to test how the presence of a Fargate node forces the use of the proxy api:
`kubectl label node <node name>  eks.amazonaws.com/compute-type=fargate`

#### Any background context you want to provide?
Disabling direct connect upon detecting Fargate nodes doesn't actually change the behavior of the agent with regard to that node, it just skips a noisy step that is bound to fail. Any clusters that have been running with the previous agent version will still have Fargate node metrics collected. However, the presence of a Fargate node does disable direct connect for all nodes in the cluster.

Fargate node metrics are currently being collected, but we don't at this time support viewing the Fargate metrics in the cloudability Containers tool. See our [KnowledgeBase documentation](https://support.cloudability.com/hc/en-us/articles/360008368193-Kubernetes-Metrics-Agent-Error-Messages) for more information.

#### What picture best describes this PR (optional but encouraged)?
[metrics-agent trying to direct connect to Fargate nodes](http://www.falseknees.com/imgs/351.png)

#### What are the relevant Github Issues?
#62 , #63 

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)