### PR TITLE
Add node ready checks to nodecollection methods: downloadNod…

### DIFF
--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	v1 "k8s.io/client-go/pkg/api/v1"
+	v1Node "k8s.io/client-go/pkg/api/v1/node"
 )
 
 // NodeSource is an interface to get a list of Nodes
@@ -81,6 +82,8 @@ func downloadNodeData(prefix string,
 		return nil, fmt.Errorf("error occurred requesting container statistics: %v", err)
 	}
 
+	anyNodeReady := false
+
 	for _, n := range nodes.Items {
 		if n.Spec.ProviderID == "" {
 			failedNodeList[n.Name] = errors.New("Provider ID for node does not exist. " +
@@ -91,6 +94,16 @@ func downloadNodeData(prefix string,
 		// The config shouldn't allow direct connection if Fargate nodes were
 		// found in the cluster at startup, but check again here to be safe.
 		if config.nodeRetrievalMethod == direct && !isFargateNode(n) {
+			// Nodes running in a cluster may not all be ready, check each node individually and if they are not ready
+			// skip the node and create a log.
+			nodeReady := v1Node.IsNodeReady(&n)
+			if !nodeReady {
+				log.Warnf("Node %s was not ready when attempting to get node summary", n.Name)
+				continue
+			} else if anyNodeReady == false {
+				anyNodeReady = true
+			}
+
 			ip, port, err := nodeSource.NodeAddress(&n)
 			if err != nil {
 				return nil, fmt.Errorf("error: %s", err)
@@ -125,6 +138,10 @@ func downloadNodeData(prefix string,
 		continue
 	}
 
+	if !anyNodeReady {
+		fmt.Errorf("error retrieving node summaries: no nodes were ready in cluster %s", config.ClusterName)
+	}
+
 	return failedNodeList, nil
 }
 
@@ -153,7 +170,22 @@ func ensureNodeSource(config KubeAgentConfig) (KubeAgentConfig, error) {
 		return config, fmt.Errorf("error retrieving nodes: %s", err)
 	}
 
-	ip, port, err := clientSetNodeSource.NodeAddress(&nodes.Items[0])
+	// Some nodes may not be ready, we want to find the first node that is ready so we can set the node source
+	var firstReadyNode *v1.Node
+
+	for _, n := range nodes.Items {
+		nodeReady := v1Node.IsNodeReady(&n)
+
+		if nodeReady {
+			firstReadyNode = &n
+		}
+	}
+
+	if firstReadyNode == nil {
+		return config, fmt.Errorf("error retrieving node addresses: no nodes were ready in cluster %s", config.ClusterName)
+	}
+
+	ip, port, err := clientSetNodeSource.NodeAddress(firstReadyNode)
 	if err != nil {
 		return config, fmt.Errorf("error retrieving node addresses: %s", err)
 	}

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -275,6 +275,34 @@ func (tns testNodeSource) GetNodes() (*v1.NodeList, error) {
 							Address: ip,
 						},
 					},
+					Conditions: []v1.NodeCondition{{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					}},
+					DaemonEndpoints: v1.NodeDaemonEndpoints{
+						KubeletEndpoint: v1.DaemonEndpoint{
+							Port: int32(port),
+						},
+					},
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR:    "",
+					ExternalID: "",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "testNotReadyNode", Namespace: v1.NamespaceDefault},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    "InternalIP",
+							Address: ip,
+						},
+					},
+					Conditions: []v1.NodeCondition{{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse,
+					}},
 					DaemonEndpoints: v1.NodeDaemonEndpoints{
 						KubeletEndpoint: v1.DaemonEndpoint{
 							Port: int32(port),


### PR DESCRIPTION
…eData and ensureNodeSource.

#### What does this PR do?
Adds a nodeready status check in the nodecollection module. In one case we want to use the first ready node to find the node source address, and when we are polling node data we want to make sure a node is ready before requesting node summaries, if the node isn't ready we will just skip it. If no nodes were ready during initialization this will result in an error as well as if no nodes were ready when we attempt to get node summaries. 
#### Where should the reviewer start?
Make sure the checks are in the right place (I'm not sure if in the downloadNodeData if it should be above the if statement it is currently nested under or not). Make sure logic looks good
#### How should this be manually tested?
Will do a manual test using one of our test clusters. 
#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)