### PR TITLE
Add node ready checks to nodecollection methods: downloadNodeData and...

### DIFF
--- a/kubernetes/export_test.go
+++ b/kubernetes/export_test.go
@@ -1,11 +1,10 @@
 package kubernetes
 
 var (
-	IsFargateNode     = isFargateNode
-	GetFirstReadyNode = getFirstReadyNode
-	EnsureNodeSource  = ensureNodeSource
-	DownloadNodeData  = downloadNodeData
-	Unreachable       = unreachable
-	Proxy             = proxy
-	Direct            = direct
+	IsFargateNode    = isFargateNode
+	EnsureNodeSource = ensureNodeSource
+	DownloadNodeData = downloadNodeData
+	Unreachable      = unreachable
+	Proxy            = proxy
+	Direct           = direct
 )

--- a/kubernetes/export_test.go
+++ b/kubernetes/export_test.go
@@ -1,10 +1,11 @@
 package kubernetes
 
 var (
-	IsFargateNode    = isFargateNode
-	EnsureNodeSource = ensureNodeSource
-	DownloadNodeData = downloadNodeData
-	Unreachable      = unreachable
-	Proxy            = proxy
-	Direct           = direct
+	IsFargateNode     = isFargateNode
+	GetFirstReadyNode = getFirstReadyNode
+	EnsureNodeSource  = ensureNodeSource
+	DownloadNodeData  = downloadNodeData
+	Unreachable       = unreachable
+	Proxy             = proxy
+	Direct            = direct
 )

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -98,7 +98,14 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 	t.Parallel()
 	t.Run("should return error if can't get node summaries", func(t *testing.T) {
 		cs := fake.NewSimpleClientset(
-			&v1.Node{Status: v1.NodeStatus{Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP}}},
+			&v1.Node{
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{{Type: v1.NodeInternalIP}},
+					Conditions: []v1.NodeCondition{{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					}},
+				},
 				ObjectMeta: metav1.ObjectMeta{Name: "node0", Namespace: v1.NamespaceDefault}},
 		)
 		config := KubeAgentConfig{
@@ -227,9 +234,18 @@ func TestCollectMetrics(t *testing.T) {
 	defer ts.Close()
 
 	cs := fake.NewSimpleClientset(
-		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0", Namespace: v1.NamespaceDefault}},
-		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Namespace: v1.NamespaceDefault}},
-		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", Namespace: v1.NamespaceDefault}},
+		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node0", Namespace: v1.NamespaceDefault}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{
+			Type:   v1.NodeReady,
+			Status: v1.ConditionTrue,
+		}}}},
+		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1", Namespace: v1.NamespaceDefault}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{
+			Type:   v1.NodeReady,
+			Status: v1.ConditionTrue,
+		}}}},
+		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node2", Namespace: v1.NamespaceDefault}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{
+			Type:   v1.NodeReady,
+			Status: v1.ConditionTrue,
+		}}}},
 	)
 
 	sv, _ := cs.Discovery().ServerVersion()

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -58,12 +58,16 @@ func (cns ClientsetNodeSource) GetReadyNodes() ([]v1.Node, error) {
 		if nodeReady {
 			readyNodes = append(readyNodes, n)
 		} else {
-			log.Infof("node, %s, is in a notready state", n.Name)
+			log.Debugf("node, %s, is in a notready state", n.Name)
 		}
 	}
 
 	if len(readyNodes) == 0 {
 		return nil, fmt.Errorf("there were 0 nodes in a ready state")
+	}
+
+	if len(readyNodes) != len(allNodes.Items) {
+		log.Info("some nodes were in a not ready when retrieving nodes")
 	}
 
 	return readyNodes, nil

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -67,7 +67,7 @@ func (cns ClientsetNodeSource) GetReadyNodes() ([]v1.Node, error) {
 	}
 
 	if len(readyNodes) != len(allNodes.Items) {
-		log.Info("some nodes were in a not ready when retrieving nodes")
+		log.Info("some nodes were in a not ready state when retrieving nodes")
 	}
 
 	return readyNodes, nil

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -48,6 +48,10 @@ func NewTestClient(ts *httptest.Server, labels map[string]string) *fake.Clientse
 						Address: ip,
 					},
 				},
+				Conditions: []v1.NodeCondition{{
+					Type:   v1.NodeReady,
+					Status: v1.ConditionTrue,
+				}},
 				DaemonEndpoints: v1.NodeDaemonEndpoints{
 					KubeletEndpoint: v1.DaemonEndpoint{
 						Port: int32(port),
@@ -180,6 +184,10 @@ func TestFargateNodeDetection(t *testing.T) {
 					Address: "1.110.235.222",
 				},
 			},
+			Conditions: []v1.NodeCondition{{
+				Type:   v1.NodeReady,
+				Status: v1.ConditionTrue,
+			}},
 			DaemonEndpoints: v1.NodeDaemonEndpoints{
 				KubeletEndpoint: v1.DaemonEndpoint{
 					Port: 80,

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -275,6 +275,34 @@ func (tns testNodeSource) GetNodes() (*v1.NodeList, error) {
 							Address: ip,
 						},
 					},
+					Conditions: []v1.NodeCondition{{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					}},
+					DaemonEndpoints: v1.NodeDaemonEndpoints{
+						KubeletEndpoint: v1.DaemonEndpoint{
+							Port: int32(port),
+						},
+					},
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR:    "",
+					ExternalID: "",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "testNotReadyNode", Namespace: v1.NamespaceDefault},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    "InternalIP",
+							Address: ip,
+						},
+					},
+					Conditions: []v1.NodeCondition{{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse,
+					}},
 					DaemonEndpoints: v1.NodeDaemonEndpoints{
 						KubeletEndpoint: v1.DaemonEndpoint{
 							Port: int32(port),

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.1.0"
+var VERSION = "1.1.1"


### PR DESCRIPTION
… ensureNodeSource.

#### What does this PR do?
Adds a nodeready status check in the nodecollection module. In one case we want to use the first ready node to find the node source address, and when we are polling node data we want to make sure a node is ready before requesting node summaries, if the node isn't ready we will just skip it. If no nodes were ready during initialization this will result in an error as well as if no nodes were ready when we attempt to get node summaries. 
#### Where should the reviewer start?
Make sure the checks are in the right place (I'm not sure if in the downloadNodeData if it should be above the if statement it is currently nested under or not). Make sure logic looks good
#### How should this be manually tested?
Will do a manual test using one of our test clusters. 
#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)