### PR TITLE
remove packaging helm archive in deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,10 +110,6 @@ jobs:
           command:  make -e container-build
 
       - run:
-          name: package helm chart
-          command: make -e helm-package
-
-      - run:
           name: push to dockerhub
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then


### PR DESCRIPTION
#### What does this PR do?
- removes the packaging of the helm chart in the deploy step

#### Where should the reviewer start?
https://github.com/cloudability/metrics-agent/compare/master...DavidXArnold:fix70?expand=1#diff-1d37e48f9ceff6d8030570cd36286a61L112

#### Any background context you want to provide?
See comments on PR #79 

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [x] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)