### PR TITLE
multiple updates to the helm chart

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 *  @egs5053
-*  @DavidXArnold
 *  @housejester
 *  @mollylogue
 *  @mnorbury

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,7 @@ container-build:
 	-t $(PREFIX)/metrics-agent:$(VERSION) -f deploy/docker/Dockerfile .
 
 helm-package:
-	helm package deploy/charts/metrics-agent \
-	--version=$(RELEASE-VERSION) \
-	--app-version=$(RELEASE-VERSION)
+	helm package deploy/charts/metrics-agent
 
 deploy-local: container-build
 	kubectl config use-context docker-for-desktop

--- a/deploy/charts/metrics-agent/Chart.yaml
+++ b/deploy/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 0.1.0
+appVersion: 1.2.0

--- a/deploy/charts/metrics-agent/templates/deployment.yaml
+++ b/deploy/charts/metrics-agent/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "metrics-agent.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "metrics-agent.selectorLabels" . | nindent 6 }}
@@ -19,11 +19,13 @@ spec:
         {{- toYaml . | nindent 8 }}
     {{- end }}
       serviceAccountName: {{ include "metrics-agent.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - 'kubernetes'
@@ -33,24 +35,24 @@ spec:
                 secretKeyRef:
                   name: {{ include "metrics-agent.fullname" . }}
                   key: CLOUDABILITY_API_KEY
-            {{- if .Values.extraEnv }}
-            {{ toYaml .Values.extraEnv | nindent 12 }}
-            {{- end }}
             - name: CLOUDABILITY_CLUSTER_NAME
               value: {{ .Values.clusterName }}
             - name: CLOUDABILITY_POLL_INTERVAL
               value: {{ .Values.pollInterval | quote }}
+            {{- if .Values.extraEnv }}
+              {{- toYaml .Values.extraEnv | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-    {{- with .Values.affinity }}
+      {{- with .Values.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}

--- a/deploy/charts/metrics-agent/templates/serviceaccount.yaml
+++ b/deploy/charts/metrics-agent/templates/serviceaccount.yaml
@@ -4,5 +4,5 @@ kind: ServiceAccount
 metadata:
   name: {{ include "metrics-agent.serviceAccountName" . }}
   labels:
-{{ include "metrics-agent.labels" . | nindent 4 }}
+    {{- include "metrics-agent.labels" . | nindent 4 }}
 {{- end -}}

--- a/deploy/charts/metrics-agent/values.yaml
+++ b/deploy/charts/metrics-agent/values.yaml
@@ -1,51 +1,49 @@
+---
 # Default values for metrics-agent.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
-image:
-  repository: cloudability/metrics-agent
-  pullPolicy: IfNotPresent
-
-imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# apiKey is REQUIRED.
+# You must generate a template to get your apiKey.
+# In the Cloudability app, go to Insights -> Containers, then click
+# the orange plus sign to provision a cluster.
 apiKey: ""
+# clusterName is REQUIRED.
+# The cluster name to be used for the cluster the agent runs in.
 clusterName: ""
+# The interval in seconds to poll metrics.
 pollInterval: 180
 
-extraEnv: []
+image:
+  name: cloudability/metrics-agent
+  tag: latest
+  pullPolicy: IfNotPresent
 
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  # name:
-
-rbac:
-  create: true
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+imagePullSecrets: []
 
 resources:
   requests:
-    memory: "128Mi"
     cpu: ".1"
+    memory: "128Mi"
   limits:
-    memory: "1Gi"
     cpu: ".5"
+    memory: "1Gi"
+
+# serviceAccount.create: true is required
+serviceAccount:
+  create: true
+
+# rbac.create: true is required
+rbac:
+  create: true
+
+# For agent configuration options, see https://github.com/cloudability/metrics-agent/blob/master/README.md
+extraEnv: []
+
+securityContext: {}
 
 nodeSelector: {}
 

--- a/deploy/charts/metrics-agent/values.yaml
+++ b/deploy/charts/metrics-agent/values.yaml
@@ -43,7 +43,8 @@ rbac:
 # For agent configuration options, see https://github.com/cloudability/metrics-agent/blob/master/README.md
 extraEnv: []
 
-securityContext: {}
+securityContext:
+  runAsUser: 1000
 
 nodeSelector: {}
 


### PR DESCRIPTION
#### What does this PR do?
Multiple changes to the helm chart
- **BREAKING CHANGE** - `deployment.yaml` now uses `image.name:image.tag` instead of `image.repository:Chart.appversion` (https://github.com/cloudability/metrics-agent/issues/83)
- `image.tag` defaults to `latest` in `values.yaml` to match what is present in the generated template provided by the Cloudability app
- Hardcode `replicaCount` to 1 in `deployment.yaml`, removed the variable from `values.yaml`. Only one copy of the agent should run.
- Bump chart version to `0.2.0`
- Bump app version to `1.2.0`
- Misc template cleanup in `deployment yaml`
- Add more information to `values.yaml` to make the values clearer.
- Remove David Arnold from `CODEOWNERS`
- Add `securityContext` (https://github.com/cloudability/metrics-agent/issues/82)

#### Where should the reviewer start?
values.yaml

#### How should this be manually tested?
`helm template cloudability .`

#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [x] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)