### PR TITLE
Use numberic USER in Dockerfile for PodSecurityPolicy set to runAsNon…

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -28,6 +28,6 @@ WORKDIR /
 
 COPY --from=build-env /go/src/${package}/${application} /${application}
 
-USER agent
+USER 1000
 
 ENTRYPOINT ["/metrics-agent"]

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.2.0"
+var VERSION = "1.2.1"


### PR DESCRIPTION
#### What does this PR do?
Use numberic USER in Dockerfile for PodSecurityPolicy set to `runAsNonRoot`

Tested in EKS 1.17 clusters, via both manifest and Helm deployment.

This fixes https://github.com/cloudability/metrics-agent/issues/85 and https://github.com/cloudability/metrics-agent/issues/82