### PR TITLE
Make metric collection retry limit configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Every 10 minutes the metrics agent creates a tarball of the gathered metrics and
 | CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
 | CLOUDABILITY_FORCE_KUBE_PROXY           | Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False|
 | CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
+| CLOUDABILITY_COLLECTION_RETRY_LIMIT     | Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 2|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 | CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
 | CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
@@ -44,6 +45,7 @@ Flags:
       --certificate_file string                  The path to a certificate file. - Optional
       --cluster_name string                      Kubernetes Cluster Name - required this must be unique to every cluster.
       --heapster_override_url string             URL to connect to a running heapster instance. - optionally override the discovered Heapster URL.
+      --collection_retry_limit uint              Number of times agent should attempt to gather metrics from each source upon a failure (default 2)
   -h, --help                                     help for kubernetes
       --insecure                                 When true, does not verify certificates when making TLS connections. Default: False
       --key_file string                          The path to a key file. - Optional

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Every 10 minutes the metrics agent creates a tarball of the gathered metrics and
 | CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
 | CLOUDABILITY_FORCE_KUBE_PROXY           | Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False|
 | CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
-| CLOUDABILITY_COLLECTION_RETRY_LIMIT     | Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 2|
+| CLOUDABILITY_COLLECTION_RETRY_LIMIT     | Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 | CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
 | CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
@@ -45,7 +45,7 @@ Flags:
       --certificate_file string                  The path to a certificate file. - Optional
       --cluster_name string                      Kubernetes Cluster Name - required this must be unique to every cluster.
       --heapster_override_url string             URL to connect to a running heapster instance. - optionally override the discovered Heapster URL.
-      --collection_retry_limit uint              Number of times agent should attempt to gather metrics from each source upon a failure (default 2)
+      --collection_retry_limit uint              Number of times agent should attempt to gather metrics from each source upon a failure (default 1)
   -h, --help                                     help for kubernetes
       --insecure                                 When true, does not verify certificates when making TLS connections. Default: False
       --key_file string                          The path to a key file. - Optional

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -54,6 +54,12 @@ func init() {
 		180,
 		"Time, in seconds, to poll the services infrastructure.",
 	)
+	kubernetesCmd.PersistentFlags().UintVar(
+		&config.CollectionRetryLimit,
+		"collection_retry_limit",
+		kubernetes.DefaultCollectionRetry,
+		"Number of times agent should attempt to gather metrics from each source upon a failure",
+	)
 	kubernetesCmd.PersistentFlags().StringVar(
 		&config.Cert,
 		"certificate_file",
@@ -126,6 +132,7 @@ func init() {
 	_ = viper.BindPFlag("cluster_name", kubernetesCmd.PersistentFlags().Lookup("cluster_name"))
 	_ = viper.BindPFlag("heapster_override_url", kubernetesCmd.PersistentFlags().Lookup("heapster_override_url"))
 	_ = viper.BindPFlag("poll_interval", kubernetesCmd.PersistentFlags().Lookup("poll_interval"))
+	_ = viper.BindPFlag("collection_retry_limit", kubernetesCmd.PersistentFlags().Lookup("collection_retry_limit"))
 	_ = viper.BindPFlag("certificate_file", kubernetesCmd.PersistentFlags().Lookup("certificate_file"))
 	_ = viper.BindPFlag("key_file", kubernetesCmd.PersistentFlags().Lookup("key_file"))
 	_ = viper.BindPFlag("outbound_proxy", kubernetesCmd.PersistentFlags().Lookup("outbound_proxy"))
@@ -149,6 +156,7 @@ func init() {
 		CollectHeapsterExport: viper.GetBool("collect_heapster_export"),
 		HeapsterOverrideURL:   viper.GetString("heapster_override_url"),
 		PollInterval:          viper.GetInt("poll_interval"),
+		CollectionRetryLimit:  viper.GetUint("collection_retry_limit"),
 		OutboundProxy:         viper.GetString("outbound_proxy"),
 		OutboundProxyAuth:     viper.GetString("outbound_proxy_auth"),
 		OutboundProxyInsecure: viper.GetBool("outbound_proxy_insecure"),

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/gostaticanalysis/analysisutil v0.0.3 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
+	github.com/onsi/gomega v1.8.1
 	github.com/sirupsen/logrus v1.4.3-0.20190701143506-07a84ee7412e
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -64,6 +64,7 @@ type KubeAgentConfig struct {
 	UseInClusterConfig    bool
 	CollectHeapsterExport bool
 	PollInterval          int
+	CollectionRetryLimit  uint
 	failedNodeList        map[string]error
 	AgentStartTime        time.Time
 	Clientset             kubernetes.Interface
@@ -81,6 +82,7 @@ type KubeAgentConfig struct {
 
 const uploadInterval time.Duration = 10
 const retryCount uint = 10
+const DefaultCollectionRetry = 2
 
 // node connection methods
 const proxy = "proxy"
@@ -94,6 +96,8 @@ const kbURL string = "https://support.cloudability.com/hc/en-us/articles/3600083
 func CollectKubeMetrics(config KubeAgentConfig) {
 
 	log.Infof("Starting Cloudability Kubernetes Metric Agent version: %v", cldyVersion.VERSION)
+	log.Infof("Metric collection retry limit set to %d (default is %d)",
+		config.CollectionRetryLimit, DefaultCollectionRetry)
 
 	validateMetricCollectionConfig(config.RetrieveNodeSummaries, config.CollectHeapsterExport)
 
@@ -428,7 +432,8 @@ func updateConfig(config KubeAgentConfig) (KubeAgentConfig, error) {
 	if err != nil {
 		return updatedConfig, err
 	}
-	updatedConfig.InClusterClient = raw.NewClient(updatedConfig.HTTPClient, config.Insecure, config.BearerToken, 3)
+	updatedConfig.InClusterClient = raw.NewClient(updatedConfig.HTTPClient, config.Insecure,
+		config.BearerToken, config.CollectionRetryLimit)
 
 	updatedConfig.clusterUID, err = getNamespaceUID(updatedConfig.Clientset, "default")
 	if err != nil {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -82,7 +82,7 @@ type KubeAgentConfig struct {
 
 const uploadInterval time.Duration = 10
 const retryCount uint = 10
-const DefaultCollectionRetry = 2
+const DefaultCollectionRetry = 1
 
 // node connection methods
 const proxy = "proxy"

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -131,7 +131,6 @@ func downloadNodeData(prefix string,
 			if err == nil {
 				continue
 			}
-			// TODO: Do we want to consider the node failed if we can still try proxy?
 			// make note of the error and fall through to proxy
 			failedNodeList[n.Name] = fmt.Errorf("direct connect failed (will attempt proxy): %s", err)
 		}
@@ -263,7 +262,7 @@ func ensureNodeSource(config KubeAgentConfig) (KubeAgentConfig, error) {
 
 	clientSetNodeSource := NewClientsetNodeSource(config.Clientset)
 
-	nodeClient := raw.NewClient(nodeHTTPClient, true, config.BearerToken, 3)
+	nodeClient := raw.NewClient(nodeHTTPClient, true, config.BearerToken, config.CollectionRetryLimit)
 
 	config.NodeClient = nodeClient
 

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cloudability/metrics-agent/kubernetes"
 	"github.com/cloudability/metrics-agent/retrieval/raw"
+	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -74,8 +75,9 @@ func TestEnsureNodeSource(t *testing.T) {
 	ts := launchTLSTestServer(returnCodes)
 	cs := NewTestClient(ts, nodeSampleLabels)
 	ka := kubernetes.KubeAgentConfig{
-		Clientset:  cs,
-		HTTPClient: http.Client{},
+		Clientset:            cs,
+		HTTPClient:           http.Client{},
+		CollectionRetryLimit: 0,
 	}
 
 	defer ts.Close()
@@ -330,6 +332,95 @@ func TestDownloadNodeData(t *testing.T) {
 			t.Error("unexpected error")
 		}
 	})
+}
+
+func TestDownloadNodeDataRetries(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	var callCount uint
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var code int
+		if callCount > 0 {
+			code = 403
+		} else {
+			code = 500
+		}
+		callCount++
+		w.WriteHeader(code)
+	}))
+	cs := NewTestClient(ts, nodeSampleLabels)
+	defer ts.Close()
+
+	t.Run("should honor max collection retry limit", func(t *testing.T) {
+		var maxRetry uint = 1
+		c := http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					// nolint gosec
+					InsecureSkipVerify: true,
+				},
+			}}
+		rc := raw.NewClient(
+			c,
+			true,
+			"",
+			maxRetry,
+		)
+		ka := kubernetes.KubeAgentConfig{
+			Clientset:             cs,
+			HTTPClient:            c,
+			InClusterClient:       rc,
+			ClusterHostURL:        "https://" + ts.Listener.Addr().String(),
+			RetrieveNodeSummaries: true,
+		}
+		wd, _ := os.Getwd()
+		ed, _ := os.Open(fmt.Sprintf("%s/testdata", wd))
+
+		ns := testNodeSource{}
+
+		s := strings.Split(ts.Listener.Addr().String(), ":")
+		ip := s[0]
+		port, _ := strconv.Atoi(s[1])
+		ns.Nodes = []v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "proxyNode", Namespace: v1.NamespaceDefault},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{
+						{
+							Type:    "InternalIP",
+							Address: ip,
+						},
+					},
+					Conditions: []v1.NodeCondition{{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					}},
+					DaemonEndpoints: v1.NodeDaemonEndpoints{
+						KubeletEndpoint: v1.DaemonEndpoint{
+							Port: int32(port),
+						},
+					},
+				},
+				Spec: v1.NodeSpec{
+					PodCIDR: "",
+				},
+			},
+		}
+
+		failedNodeList, err := kubernetes.DownloadNodeData(
+			"baseline",
+			ka,
+			ed,
+			ns,
+		)
+		g.Expect(err).To(gomega.BeNil())
+		// just one node in the list to attempt fetch from
+		g.Expect(failedNodeList).To(gomega.HaveLen(1), "the node passed in is unreachable")
+		// the config doesn't specify direct connect, so
+		// only proxy connection is attempted here
+		maxAttempts := maxRetry + 1
+		g.Expect(callCount).To(gomega.Equal(maxAttempts), "should fail up to maxRetry + 1 times")
+	})
+
 }
 
 type testNodeSource struct {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.2.2"
+var VERSION = "1.3.0"


### PR DESCRIPTION
#### What does this PR do?
Make the collection retry limit configurable. Currently the retry limit is hard-coded to 3 with an added backoff each time, which can cause the agent to spend an excessive amount of time attempting to connect to a node that is no longer in the cluster. This is problematic for very large clusters, or clusters with heavy spot usage.

Users who know they have a highly dynamic cluster may choose to set a lower retry limit to address this issue.

#### Where should the reviewer start?
kubernetes/kubernetes.go:435 and kubernetes/nodecollection.go:265 is where the new retry value is passed to the client. The rest of the changes are just threading this value through.

#### How should this be manually tested?
You can run the agent locally with a flag or env var to alter the retries.

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)