### PR TITLE
Revert "Make metric collection retry limit configurable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Every 10 minutes the metrics agent creates a tarball of the gathered metrics and
 | CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
 | CLOUDABILITY_FORCE_KUBE_PROXY           | Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False|
 | CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
-| CLOUDABILITY_COLLECTION_RETRY_LIMIT     | Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1|
 | CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
 | CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
 | CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
@@ -45,7 +44,6 @@ Flags:
       --certificate_file string                  The path to a certificate file. - Optional
       --cluster_name string                      Kubernetes Cluster Name - required this must be unique to every cluster.
       --heapster_override_url string             URL to connect to a running heapster instance. - optionally override the discovered Heapster URL.
-      --collection_retry_limit uint              Number of times agent should attempt to gather metrics from each source upon a failure (default 1)
   -h, --help                                     help for kubernetes
       --insecure                                 When true, does not verify certificates when making TLS connections. Default: False
       --key_file string                          The path to a key file. - Optional

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -54,12 +54,6 @@ func init() {
 		180,
 		"Time, in seconds, to poll the services infrastructure.",
 	)
-	kubernetesCmd.PersistentFlags().UintVar(
-		&config.CollectionRetryLimit,
-		"collection_retry_limit",
-		kubernetes.DefaultCollectionRetry,
-		"Number of times agent should attempt to gather metrics from each source upon a failure",
-	)
 	kubernetesCmd.PersistentFlags().StringVar(
 		&config.Cert,
 		"certificate_file",
@@ -132,7 +126,6 @@ func init() {
 	_ = viper.BindPFlag("cluster_name", kubernetesCmd.PersistentFlags().Lookup("cluster_name"))
 	_ = viper.BindPFlag("heapster_override_url", kubernetesCmd.PersistentFlags().Lookup("heapster_override_url"))
 	_ = viper.BindPFlag("poll_interval", kubernetesCmd.PersistentFlags().Lookup("poll_interval"))
-	_ = viper.BindPFlag("collection_retry_limit", kubernetesCmd.PersistentFlags().Lookup("collection_retry_limit"))
 	_ = viper.BindPFlag("certificate_file", kubernetesCmd.PersistentFlags().Lookup("certificate_file"))
 	_ = viper.BindPFlag("key_file", kubernetesCmd.PersistentFlags().Lookup("key_file"))
 	_ = viper.BindPFlag("outbound_proxy", kubernetesCmd.PersistentFlags().Lookup("outbound_proxy"))
@@ -156,7 +149,6 @@ func init() {
 		CollectHeapsterExport: viper.GetBool("collect_heapster_export"),
 		HeapsterOverrideURL:   viper.GetString("heapster_override_url"),
 		PollInterval:          viper.GetInt("poll_interval"),
-		CollectionRetryLimit:  viper.GetUint("collection_retry_limit"),
 		OutboundProxy:         viper.GetString("outbound_proxy"),
 		OutboundProxyAuth:     viper.GetString("outbound_proxy_auth"),
 		OutboundProxyInsecure: viper.GetBool("outbound_proxy_insecure"),

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/gostaticanalysis/analysisutil v0.0.3 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
-	github.com/onsi/gomega v1.8.1
 	github.com/sirupsen/logrus v1.4.3-0.20190701143506-07a84ee7412e
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -64,7 +64,6 @@ type KubeAgentConfig struct {
 	UseInClusterConfig    bool
 	CollectHeapsterExport bool
 	PollInterval          int
-	CollectionRetryLimit  uint
 	failedNodeList        map[string]error
 	AgentStartTime        time.Time
 	Clientset             kubernetes.Interface
@@ -82,7 +81,6 @@ type KubeAgentConfig struct {
 
 const uploadInterval time.Duration = 10
 const retryCount uint = 10
-const DefaultCollectionRetry = 1
 
 // node connection methods
 const proxy = "proxy"
@@ -96,8 +94,6 @@ const kbURL string = "https://support.cloudability.com/hc/en-us/articles/3600083
 func CollectKubeMetrics(config KubeAgentConfig) {
 
 	log.Infof("Starting Cloudability Kubernetes Metric Agent version: %v", cldyVersion.VERSION)
-	log.Infof("Metric collection retry limit set to %d (default is %d)",
-		config.CollectionRetryLimit, DefaultCollectionRetry)
 
 	validateMetricCollectionConfig(config.RetrieveNodeSummaries, config.CollectHeapsterExport)
 
@@ -432,8 +428,7 @@ func updateConfig(config KubeAgentConfig) (KubeAgentConfig, error) {
 	if err != nil {
 		return updatedConfig, err
 	}
-	updatedConfig.InClusterClient = raw.NewClient(updatedConfig.HTTPClient, config.Insecure,
-		config.BearerToken, config.CollectionRetryLimit)
+	updatedConfig.InClusterClient = raw.NewClient(updatedConfig.HTTPClient, config.Insecure, config.BearerToken, 3)
 
 	updatedConfig.clusterUID, err = getNamespaceUID(updatedConfig.Clientset, "default")
 	if err != nil {

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -131,6 +131,7 @@ func downloadNodeData(prefix string,
 			if err == nil {
 				continue
 			}
+			// TODO: Do we want to consider the node failed if we can still try proxy?
 			// make note of the error and fall through to proxy
 			failedNodeList[n.Name] = fmt.Errorf("direct connect failed (will attempt proxy): %s", err)
 		}
@@ -262,7 +263,7 @@ func ensureNodeSource(config KubeAgentConfig) (KubeAgentConfig, error) {
 
 	clientSetNodeSource := NewClientsetNodeSource(config.Clientset)
 
-	nodeClient := raw.NewClient(nodeHTTPClient, true, config.BearerToken, config.CollectionRetryLimit)
+	nodeClient := raw.NewClient(nodeHTTPClient, true, config.BearerToken, 3)
 
 	config.NodeClient = nodeClient
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.3.0"
+var VERSION = "1.2.2"


### PR DESCRIPTION
Reverts cloudability/metrics-agent#91

Our CI builds aren't working, so revert this change until we can troubleshoot that.