### PR TITLE
Modify 'quick' test to limit generated data

### DIFF
--- a/measurement/measurement_test.go
+++ b/measurement/measurement_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -130,10 +131,22 @@ func TestMarshalJSON(t *testing.T) {
 		}
 	})
 }
+
+type testMeasurement measurement.Measurement
+
+func (t testMeasurement) Generate(rand *rand.Rand, size int) reflect.Value {
+	tm := testMeasurement{
+		Name:      test.SecureRandomAlphaString(size),
+		Timestamp: rand.Int63(),
+		Value:     rand.Float64(),
+	}
+	return reflect.ValueOf(tm)
+}
+
 func TestMarshalJSON_Blackbox(t *testing.T) {
 	t.Parallel()
 
-	assertion := func(m measurement.Measurement) bool {
+	assertion := func(m testMeasurement) bool {
 		res, err := json.Marshal(m)
 		jsonString := string(res)
 


### PR DESCRIPTION
#### What does this PR do?

Modifies the blackbox 'quick' test to only use alpha characters in the name. This fixes a flaky test where Unicode characters were failing.

#### Where should the reviewer start?

https://github.com/cloudability/metrics-agent/compare/fix_flakey_test?expand=1#diff-e5a65ebb7808f7ba79fae5c6d600e40e0c13b8d9bee63cd78797bc0f2aa2a23dR139

#### How should this be manually tested?

Confirmed the test passes in CI

#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)