### PR TITLE
Encode connection type at the endpoint level rather than the cluster level

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,14 @@
+# Path to sources
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**
+
+# Path to tests
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**
+
+# Source encoding
+#sonar.sourceEncoding=UTF-8
+
+# Exclusions for copy-paste detection
+#sonar.cpd.exclusions=

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Kubernetes versions 1.17 and below are supported by the metrics agent.
 | CLOUDABILITY_OUTBOUND_PROXY_INSECURE    | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
 | CLOUDABILITY_INSECURE                   | Optional: When true, does not verify certificates when making TLS connections. Default: False|
 | CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
-| CLOUDABILITY_RETRIEVE_STATS_CONTAINER   | Optional: When true, attempts to collects metrics from the stats/container endpoint if available. When False, does not collect stats/container metrics. Default: True.
+| CLOUDABILITY_GET_ALL_CONTAINER_STATS    | Optional: When true, attempts to collect from both the stats/container and metrics/cadvisor endpoints, which may result in a larger metrics payload. When False, only collects first successful endpoint. Default: True|
 | CLOUDABILITY_FORCE_KUBE_PROXY           | Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False|
 | CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
 | CLOUDABILITY_COLLECTION_RETRY_LIMIT     | Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1|
@@ -77,6 +77,7 @@ Flags:
       --outbound_proxy_auth string               Outbound proxy basic authentication credentials. Must defined in the form username:password - Optional
       --outbound_proxy_insecure                  When true, does not verify TLS certificates when using the outbound proxy. Default: False
       --retrieve_node_summaries                  When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True
+      --get_all_container_stats                  When true, attempts to collect from both the stats/container and metrics/cadvisor endpoints, which may result in a larger metrics payload. Default: True
       --force_kube_proxy                         When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False
       --poll_interval int                        Time, in seconds, to poll the services infrastructure. Default: 180 (default 180)
       --namespace string                         The namespace which the agent runs in. Changing this is not recommended. (default `cloudability`)

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -103,10 +103,10 @@ func init() {
 		"When true, includes node summary metrics in metric collection.",
 	)
 	kubernetesCmd.PersistentFlags().BoolVar(
-		&config.RetrieveStatsContainer,
-		"retrieve_stats_container",
+		&config.GetAllConStats,
+		"get_all_container_stats",
 		true,
-		"When true, includes stats container metrics in metric collection. Default: True",
+		"When true, includes all available container metrics in metric collection. Default: True",
 	)
 	kubernetesCmd.PersistentFlags().BoolVar(
 		&config.ForceKubeProxy,
@@ -146,7 +146,7 @@ func init() {
 	_ = viper.BindPFlag("outbound_proxy_insecure", kubernetesCmd.PersistentFlags().Lookup("outbound_proxy_insecure"))
 	_ = viper.BindPFlag("insecure", kubernetesCmd.PersistentFlags().Lookup("insecure"))
 	_ = viper.BindPFlag("retrieve_node_summaries", kubernetesCmd.PersistentFlags().Lookup("retrieve_node_summaries"))
-	_ = viper.BindPFlag("retrieve_stats_container", kubernetesCmd.PersistentFlags().Lookup("retrieve_stats_container"))
+	_ = viper.BindPFlag("get_all_container_stats", kubernetesCmd.PersistentFlags().Lookup("get_all_container_stats"))
 	_ = viper.BindPFlag("force_kube_proxy", kubernetesCmd.PersistentFlags().Lookup("force_kube_proxy"))
 	_ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
 	_ = viper.BindPFlag("collect_heapster_export", kubernetesCmd.PersistentFlags().Lookup("collect_heapster_export"))
@@ -158,23 +158,23 @@ func init() {
 	RootCmd.AddCommand(kubernetesCmd)
 
 	config = kubernetes.KubeAgentConfig{
-		APIKey:                 viper.GetString("api_key"),
-		ClusterName:            viper.GetString("cluster_name"),
-		CollectHeapsterExport:  viper.GetBool("collect_heapster_export"),
-		HeapsterOverrideURL:    viper.GetString("heapster_override_url"),
-		PollInterval:           viper.GetInt("poll_interval"),
-		CollectionRetryLimit:   viper.GetUint("collection_retry_limit"),
-		OutboundProxy:          viper.GetString("outbound_proxy"),
-		OutboundProxyAuth:      viper.GetString("outbound_proxy_auth"),
-		OutboundProxyInsecure:  viper.GetBool("outbound_proxy_insecure"),
-		Insecure:               viper.GetBool("insecure"),
-		Cert:                   viper.GetString("certificate_file"),
-		Key:                    viper.GetString("key_file"),
-		RetrieveNodeSummaries:  viper.GetBool("retrieve_node_summaries"),
-		RetrieveStatsContainer: viper.GetBool("retrieve_stats_container"),
-		ForceKubeProxy:         viper.GetBool("force_kube_proxy"),
-		Namespace:              viper.GetString("namespace"),
-		ScratchDir:             viper.GetString("scratch_dir"),
+		APIKey:                viper.GetString("api_key"),
+		ClusterName:           viper.GetString("cluster_name"),
+		CollectHeapsterExport: viper.GetBool("collect_heapster_export"),
+		HeapsterOverrideURL:   viper.GetString("heapster_override_url"),
+		PollInterval:          viper.GetInt("poll_interval"),
+		CollectionRetryLimit:  viper.GetUint("collection_retry_limit"),
+		OutboundProxy:         viper.GetString("outbound_proxy"),
+		OutboundProxyAuth:     viper.GetString("outbound_proxy_auth"),
+		OutboundProxyInsecure: viper.GetBool("outbound_proxy_insecure"),
+		Insecure:              viper.GetBool("insecure"),
+		Cert:                  viper.GetString("certificate_file"),
+		Key:                   viper.GetString("key_file"),
+		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
+		GetAllConStats:        viper.GetBool("get_all_container_stats"),
+		ForceKubeProxy:        viper.GetBool("force_kube_proxy"),
+		Namespace:             viper.GetString("namespace"),
+		ScratchDir:            viper.GetString("scratch_dir"),
 	}
 
 }

--- a/kubernetes/endpoint.go
+++ b/kubernetes/endpoint.go
@@ -1,0 +1,108 @@
+package kubernetes
+
+import (
+	"strings"
+
+	"github.com/cloudability/metrics-agent/retrieval/raw"
+)
+
+// Connection is a bitmask that describes the manner(s) in which
+// the agent can connect to an endpoint
+type Connection uint8
+
+const (
+	// By bitshifting each constant with iota we can use Connection as a bitmask
+	Direct Connection = 1 << iota // 0001 = 1
+	Proxy                         // 0010 = 2
+	// Unreachable defined at end to avoid affecting iota,
+	// as it should always be set to 0
+	Unreachable Connection = 0
+)
+
+func (c Connection) hasMethod(method Connection) bool { return c&method != 0 }
+
+// AddMethod adds the provided nonzero method to the bitmask (use SetUnreachable for Unreachable)
+func (c *Connection) AddMethod(method Connection) { *c |= method }
+
+// ClearMethod removes the method from the bitmask
+func (c *Connection) ClearMethod(method Connection) { *c &= ^method }
+
+// SetUnreachable sets the connection as unreachable
+func (c *Connection) SetUnreachable() { *c = 0 }
+
+func (c Connection) String() string {
+	if c == Unreachable {
+		return unreachable
+	}
+	var options []string
+	if c.hasMethod(Proxy) {
+		options = append(options, proxy)
+	}
+	if c.hasMethod(Direct) {
+		options = append(options, direct)
+	}
+	return strings.Join(options, ",")
+}
+
+type ConnectionMethod struct {
+	ConnType     Connection
+	API          nodeAPI
+	client       raw.Client
+	FriendlyName string
+}
+
+// Endpoint represents the various metrics endpoints we hit
+type Endpoint string
+
+const (
+	// NodeStatsSummaryEndpoint the /stats/summary endpoint
+	NodeStatsSummaryEndpoint Endpoint = "/stats/summary"
+
+	// NodeContainerEndpoint the /stats/container endpoint
+	NodeContainerEndpoint Endpoint = "/stats/container"
+
+	// NodeCadvisorEndpoint the /metrics/cadvisor endpoint
+	NodeCadvisorEndpoint Endpoint = "/metrics/cadvisor"
+)
+
+// EndpointMask a map representing the currently active endpoints.
+// The keys of the map are the currently active endpoints.
+type EndpointMask map[Endpoint]Connection
+
+// SetAvailability sets an endpoint availability state according to the supplied boolean
+func (m EndpointMask) SetAvailability(endpoint Endpoint, method Connection, available bool) {
+	e := m[endpoint]
+	if available {
+		e.AddMethod(method)
+	} else {
+		e.ClearMethod(method)
+	}
+	m[endpoint] = e
+}
+
+func (m EndpointMask) SetUnreachable(endpoint Endpoint) {
+	e := m[endpoint]
+	e.SetUnreachable()
+	m[endpoint] = e
+}
+
+// Available gets the availability of an endpoint for the specified connection method
+func (m EndpointMask) Available(endpoint Endpoint, method Connection) bool {
+	return m[endpoint].hasMethod(method)
+}
+
+func (m EndpointMask) Unreachable(endpoint Endpoint) bool {
+	return m[endpoint] == Unreachable
+}
+
+func (m EndpointMask) DirectAllowed(endpoint Endpoint) bool {
+	return m[endpoint].hasMethod(Direct)
+}
+
+func (m EndpointMask) ProxyAllowed(endpoint Endpoint) bool {
+	return m[endpoint].hasMethod(Proxy)
+}
+
+func (m EndpointMask) Options(endpoint Endpoint) string {
+	return m[endpoint].String()
+}

--- a/kubernetes/endpoint_test.go
+++ b/kubernetes/endpoint_test.go
@@ -1,0 +1,162 @@
+package kubernetes
+
+import (
+	"testing"
+)
+
+func TestConnection(t *testing.T) {
+	t.Run("Connection bitmask handles Unreachable correctly", func(t *testing.T) {
+		exampleConnection := Connection(0)
+		if exampleConnection != Unreachable {
+			t.Errorf("zero-value Connection should be unreachable, got %s", exampleConnection)
+		}
+		// make sure no weird shenanigans happen with double Unreachable
+		exampleConnection.ClearMethod(Unreachable)
+		if exampleConnection != Unreachable {
+			t.Errorf("zero-value Connection should be unreachable, got %s", exampleConnection)
+		}
+		// note: Don't do this, use SetUnreachable
+		exampleConnection.AddMethod(Unreachable)
+		if exampleConnection != Unreachable {
+			t.Errorf("zero-value Connection should be unreachable, got %s", exampleConnection)
+		}
+
+		exampleConnection.SetUnreachable()
+		if exampleConnection != Unreachable {
+			t.Errorf("zero-value Connection should be unreachable, got %s", exampleConnection)
+		}
+	})
+	t.Run("Connection bitmask handles Proxy correctly", func(t *testing.T) {
+		exampleConnection := Connection(0)
+		exampleConnection.AddMethod(Proxy)
+
+		if !exampleConnection.hasMethod(Proxy) {
+			t.Errorf("expected Proxy, got %s", exampleConnection)
+		}
+		exampleConnection.ClearMethod(Proxy)
+		if exampleConnection != Unreachable {
+			t.Errorf("cleared connection should be unreachable, got %s", exampleConnection)
+		}
+	})
+	t.Run("Connection bitmask handles Direct correctly", func(t *testing.T) {
+		exampleConnection := Connection(0)
+		exampleConnection.AddMethod(Direct)
+
+		if !exampleConnection.hasMethod(Direct) {
+			t.Errorf("expected Direct, got %s", exampleConnection)
+		}
+		exampleConnection.ClearMethod(Direct)
+		if exampleConnection != Unreachable {
+			t.Errorf("cleared connection should be unreachable, got %s", exampleConnection)
+		}
+	})
+
+	t.Run("Connection bitmask handles multiple flags correctly", func(t *testing.T) {
+		exampleConnection := Connection(0)
+		exampleConnection.AddMethod(Direct)
+		exampleConnection.AddMethod(Proxy)
+
+		// should have both methods set
+		if !exampleConnection.hasMethod(Direct) {
+			t.Errorf("expected Direct, got %s", exampleConnection)
+		}
+		if !exampleConnection.hasMethod(Proxy) {
+			t.Errorf("expected Proxy, got %s", exampleConnection)
+		}
+		// should not be Unreachable
+		if exampleConnection.hasMethod(Unreachable) {
+			t.Errorf("connection should not be unreachable, got %s", exampleConnection)
+		}
+
+		exampleConnection.ClearMethod(Direct)
+
+		// should have lost direct but not proxy
+		if exampleConnection.hasMethod(Direct) {
+			t.Errorf("should not have Direct, got %s", exampleConnection)
+		}
+		if !exampleConnection.hasMethod(Proxy) {
+			t.Errorf("expected Proxy, got %s", exampleConnection)
+		}
+
+		exampleConnection.SetUnreachable()
+
+		if exampleConnection.hasMethod(Direct) {
+			t.Errorf("expected Unreachable, got %s", exampleConnection)
+		}
+		if exampleConnection.hasMethod(Proxy) {
+			t.Errorf("expectedUnreachable, got %s", exampleConnection)
+		}
+
+	})
+}
+
+func TestEndpointMask(t *testing.T) {
+	t.Run("endpoint should report Unreachable correctly", func(t *testing.T) {
+		mask := EndpointMask{}
+		if !mask.Unreachable(NodeCadvisorEndpoint) {
+			t.Error("empty mask should return all endpoints as unreachable")
+		}
+
+		// Don't do this weird stuff, use mask.SetUnreachable
+		mask.SetAvailability(NodeCadvisorEndpoint, Unreachable, false)
+		if !mask.Unreachable(NodeCadvisorEndpoint) {
+			t.Errorf("endpoint should have remained unreachable")
+		}
+
+		mask.SetAvailability(NodeCadvisorEndpoint, Proxy, true)
+		if !mask.ProxyAllowed(NodeCadvisorEndpoint) {
+			t.Errorf("should have proxy method set, instead got: %s", mask.Options(NodeCadvisorEndpoint))
+		}
+
+		mask.SetUnreachable(NodeCadvisorEndpoint)
+		if !mask.Unreachable(NodeCadvisorEndpoint) {
+			t.Errorf("expected unreachable, got %s", mask.Options(NodeCadvisorEndpoint))
+		}
+	})
+	t.Run("endpoint should set availability correctly", func(t *testing.T) {
+		mask := EndpointMask{}
+		// set as available
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
+		if !mask.DirectAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected direct connection allowed, but got %s", mask.Options(NodeStatsSummaryEndpoint))
+		}
+		if mask.ProxyAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected direct connection allowed, but got %s", mask.Options(NodeStatsSummaryEndpoint))
+		}
+
+		// set unavailable
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, false)
+		if mask.DirectAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected direct connection allowed, but got %s", mask.Options(NodeStatsSummaryEndpoint))
+		}
+		// an endpoint with no methods available should be unreachable
+		if !mask.Unreachable(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected unreachable, got %s", mask.Options(NodeCadvisorEndpoint))
+		}
+	})
+	t.Run("should be able to set multiple connection methods per endpoint", func(t *testing.T) {
+		mask := EndpointMask{}
+		if mask.ProxyAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected the availability of an endpoint to default to false")
+		}
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)
+		if !mask.ProxyAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected the availability of an endpoint to be true after being set as available")
+		}
+		// validate that setting another method doesn't unset the first
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
+		if !mask.ProxyAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected the availability of an endpoint to be true after being set as available")
+		}
+		// validate that setting the same method twice does not unset
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
+		if !mask.DirectAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected the availability of an endpoint to be true after being set as available")
+		}
+		if mask.Unreachable(NodeStatsSummaryEndpoint) {
+			t.Errorf("endpoint should be available, instead got: %s",
+				mask.Options(NodeStatsSummaryEndpoint))
+		}
+
+	})
+}

--- a/kubernetes/endpoint_test.go
+++ b/kubernetes/endpoint_test.go
@@ -68,6 +68,10 @@ func TestConnection(t *testing.T) {
 			t.Errorf("connection should not be unreachable, got %s", exampleConnection)
 		}
 
+		if !exampleConnection.hasMethod(Direct | Proxy) {
+			t.Errorf("expected to be able to check multiple flags at once")
+		}
+
 		exampleConnection.ClearMethod(Direct)
 
 		// should have lost direct but not proxy

--- a/kubernetes/endpoint_test.go
+++ b/kubernetes/endpoint_test.go
@@ -127,7 +127,7 @@ func TestEndpointMask(t *testing.T) {
 		// set unavailable
 		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, false)
 		if mask.DirectAllowed(NodeStatsSummaryEndpoint) {
-			t.Errorf("expected direct connection allowed, but got %s", mask.Options(NodeStatsSummaryEndpoint))
+			t.Errorf("expected direct connection unavailable, but got %s", mask.Options(NodeStatsSummaryEndpoint))
 		}
 		// an endpoint with no methods available should be unreachable
 		if !mask.Unreachable(NodeStatsSummaryEndpoint) {

--- a/kubernetes/export_test.go
+++ b/kubernetes/export_test.go
@@ -1,11 +1,7 @@
 package kubernetes
 
 var (
-	IsFargateNode           = isFargateNode
-	EnsureNodeSource        = ensureNodeSource
-	DownloadNodeData        = downloadNodeData
-	UpdateWithEndpointMasks = updateWithEndpointMasks
-	Unreachable             = unreachable
-	Proxy                   = proxy
-	Direct                  = direct
+	IsFargateNode    = isFargateNode
+	EnsureNodeSource = ensureNodeSource
+	DownloadNodeData = downloadNodeData
 )

--- a/kubernetes/export_test.go
+++ b/kubernetes/export_test.go
@@ -1,7 +1,0 @@
-package kubernetes
-
-var (
-	IsFargateNode    = isFargateNode
-	EnsureNodeSource = ensureNodeSource
-	DownloadNodeData = downloadNodeData
-)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -130,7 +130,7 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 		log.Warnf("Warning: Non-fatal error occurred retrieving baseline metrics: %s", err)
 	}
 
-	log.Infof("Cloudability Metrics Agent successfully started.")
+	log.Info("Cloudability Metrics Agent successfully started.")
 
 	for {
 		select {
@@ -150,7 +150,7 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 				}
 			}
 			//Send metric sample
-			log.Infof("Uploading Metrics")
+			log.Info("Uploading Metrics")
 			go kubeAgent.sendMetrics(metricSample)
 
 		case <-pollChan.C:
@@ -175,7 +175,7 @@ func validateMetricCollectionConfig(config KubeAgentConfig) {
 		if config.GetAllConStats {
 			log.Info("All available node container metrics will be collected.")
 		} else {
-			log.Infof("Minimum viable set of node container metrics will be collected.")
+			log.Info("Minimum viable set of node container metrics will be collected.")
 		}
 	}
 	if config.RetrieveNodeSummaries && config.CollectHeapsterExport {

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -303,10 +303,12 @@ func TestCollectMetrics(t *testing.T) {
 			t.Error(err)
 		}
 
-		// TODO: add cprom files to this list
 		nodeBaselineFiles := []string{}
 		nodeSummaryFiles := []string{}
 		expectedBaselineFiles := []string{
+			"baseline-cadvisor_metrics-node0.json",
+			"baseline-cadvisor_metrics-node1.json",
+			"baseline-cadvisor_metrics-node2.json",
 			"baseline-container-node0.json",
 			"baseline-container-node1.json",
 			"baseline-container-node2.json",
@@ -315,6 +317,9 @@ func TestCollectMetrics(t *testing.T) {
 			"baseline-summary-node2.json",
 		}
 		expectedSummaryFiles := []string{
+			"stats-cadvisor_metrics-node0.json",
+			"stats-cadvisor_metrics-node1.json",
+			"stats-cadvisor_metrics-node2.json",
 			"stats-container-node0.json",
 			"stats-container-node1.json",
 			"stats-container-node2.json",
@@ -327,21 +332,21 @@ func TestCollectMetrics(t *testing.T) {
 
 			if strings.HasPrefix(info.Name(), "stats-") || strings.HasPrefix(info.Name(), "baseline-") {
 
-				if strings.Contains(info.Name(), "baseline-summary") || strings.Contains(info.Name(), "baseline-container-") {
+				if isRequiredFile(info.Name(), "baseline-") {
 					nodeBaselineFiles = append(nodeBaselineFiles, info.Name())
 				}
-				if strings.Contains(info.Name(), "stats-summary") || strings.Contains(info.Name(), "stats-container-") {
+				if isRequiredFile(info.Name(), "stats-") {
 					nodeSummaryFiles = append(nodeSummaryFiles, info.Name())
 				}
 			}
 			return nil
 		})
 		if len(nodeBaselineFiles) != len(expectedBaselineFiles) {
-			t.Errorf("Expected %d baseline metrics, instead got %d", len(expectedSummaryFiles), len(nodeBaselineFiles))
+			t.Errorf("Expected %d baseline metrics, instead got %d", len(expectedBaselineFiles), len(nodeBaselineFiles))
 			return
 		}
 		if len(nodeSummaryFiles) != len(expectedSummaryFiles) {
-			t.Errorf("Expected %d summary metrics, instead got %d", len(expectedSummaryFiles), len(nodeBaselineFiles))
+			t.Errorf("Expected %d summary metrics, instead got %d", len(expectedSummaryFiles), len(nodeSummaryFiles))
 			return
 		}
 		for i, n := range expectedBaselineFiles {
@@ -351,11 +356,27 @@ func TestCollectMetrics(t *testing.T) {
 		}
 		for i, n := range expectedSummaryFiles {
 			if n != nodeSummaryFiles[i] {
-				t.Errorf("Expected file name %s instead got %s", n, nodeBaselineFiles[i])
+				t.Errorf("Expected file name %s instead got %s", n, nodeSummaryFiles[i])
 			}
 		}
 	})
 
+}
+
+// isRequiredFile checks if the filename matches one of the filenames
+// we require to be in a metrics payload
+// ex: baseline-summary
+func isRequiredFile(filename string, fileType string) bool {
+	if strings.Contains(filename, fileType+"summary") {
+		return true
+	}
+	if strings.Contains(filename, fileType+"container-") {
+		return true
+	}
+	if strings.Contains(filename, fileType+"cadvisor_metrics-") {
+		return true
+	}
+	return false
 }
 
 func TestExtractNodeNameAndExtension(t *testing.T) {

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -112,6 +112,7 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 			RetrieveNodeSummaries: true,
 			CollectHeapsterExport: false,
 			Clientset:             cs,
+			MetricsEndpoints:      EndpointMask{},
 		}
 		config, err := ensureMetricServicesAvailable(config)
 		if err == nil {
@@ -277,10 +278,9 @@ func TestCollectMetrics(t *testing.T) {
 		RetrieveNodeSummaries: true,
 		ForceKubeProxy:        false,
 	}
-
-	ka = updateWithEndpointMasks(ka)
-	ka.ProxyEndpointMask.SetAvailable(NodeStatsSummaryEndpoint, true)
-	ka.ProxyEndpointMask.SetAvailable(NodeContainerEndpoint, true)
+	ka.MetricsEndpoints = EndpointMask{}
+	ka.MetricsEndpoints.SetAvailable(NodeStatsSummaryEndpoint, Proxy, true)
+	ka.MetricsEndpoints.SetAvailable(NodeContainerEndpoint, Proxy, true)
 
 	ka.InClusterClient = raw.NewClient(ka.HTTPClient, ka.Insecure, ka.BearerToken, 0)
 	fns := NewClientsetNodeSource(cs)

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -282,12 +282,12 @@ func TestCollectMetrics(t *testing.T) {
 	}
 	ka.NodeMetrics = EndpointMask{}
 	// set Proxy method available
-	ka.NodeMetrics.SetAvailable(NodeStatsSummaryEndpoint, Proxy, true)
-	ka.NodeMetrics.SetAvailable(NodeContainerEndpoint, Proxy, true)
-	ka.NodeMetrics.SetAvailable(NodeCadvisorEndpoint, Proxy, true)
+	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)
+	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Proxy, true)
+	ka.NodeMetrics.SetAvailability(NodeCadvisorEndpoint, Proxy, true)
 	// set Direct as option as well
-	ka.NodeMetrics.SetAvailable(NodeStatsSummaryEndpoint, Direct, true)
-	ka.NodeMetrics.SetAvailable(NodeContainerEndpoint, Direct, true)
+	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
+	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Direct, true)
 
 	ka.InClusterClient = raw.NewClient(ka.HTTPClient, ka.Insecure, ka.BearerToken, 0)
 	fns := NewClientsetNodeSource(cs)

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -89,12 +89,12 @@ func (cns ClientsetNodeSource) NodeAddress(node *v1.Node) (string, int32, error)
 
 // Connection is a bitmask that describes the manner(s) in which
 // the agent can connect to an endpoint
-type Connection uint16
+type Connection uint8
 
 const (
-	Direct Connection = 1 << iota
+	Unreachable Connection = 0
+	Direct      Connection = 1 << iota
 	Proxy
-	Unreachable
 )
 
 func (c Connection) HasMethod(method Connection) bool { return c&method != 0 }
@@ -103,21 +103,28 @@ func (c *Connection) ClearMethod(method Connection)   { *c &= ^method }
 func (c *Connection) ToggleMethod(method Connection)  { *c ^= method }
 
 func (c Connection) String() string {
-	if c.HasMethod(Unreachable) {
-		return "unreachable"
+	if c == Unreachable {
+		return unreachable
 	}
 	var options []string
 	if c.HasMethod(Proxy) {
-		options = append(options, "proxy")
+		options = append(options, proxy)
 	}
 	if c.HasMethod(Direct) {
-		options = append(options, "direct")
+		options = append(options, direct)
 	}
 	return strings.Join(options, ",")
 }
 
+type ConnectionMethod struct {
+	ConnType     Connection
+	API          nodeAPI
+	client       raw.Client
+	FriendlyName string
+}
+
 // Endpoint an enumeration representing the various metrics endpoints
-type Endpoint uint16
+type Endpoint uint8
 
 const (
 	// NodeStatsSummaryEndpoint the /stats/summary endpoint
@@ -154,6 +161,22 @@ func (m EndpointMask) Available(endpoint Endpoint, method Connection) bool {
 	return e.HasMethod(method)
 }
 
+func (m EndpointMask) Unreachable(endpoint Endpoint) bool {
+	return m[endpoint] == Unreachable
+}
+
+func (m EndpointMask) DirectAllowed(endpoint Endpoint) bool {
+	return m[endpoint].HasMethod(Direct)
+}
+
+func (m EndpointMask) ProxyAllowed(endpoint Endpoint) bool {
+	return m[endpoint].HasMethod(Proxy)
+}
+
+func (m EndpointMask) Options(endpoint Endpoint) string {
+	return m[endpoint].String()
+}
+
 func downloadNodeData(prefix string,
 	config KubeAgentConfig,
 	workDir *os.File,
@@ -172,7 +195,6 @@ func downloadNodeData(prefix string,
 	}
 
 	containersRequest, err := buildContainersRequest()
-
 	if err != nil {
 		return nil, fmt.Errorf("error occurred requesting container statistics: %v", err)
 	}
@@ -190,24 +212,9 @@ func downloadNodeData(prefix string,
 			ClusterHostURL:    config.ClusterHostURL,
 			containersRequest: containersRequest,
 		}
-		// retrieve node summary directly from node if possible and allowed.
-		// The config shouldn't allow direct connection if Fargate nodes were
-		// found in the cluster at startup, but check again here to be safe.
-		if config.nodeRetrievalMethod.HasMethod(Direct) && !isFargateNode(n) {
-			err := directNodeFetch(nodeSource, config, &n, nd)
-			// no error, no need to try proxy
-			if err == nil {
-				continue
-			}
-			// make note of the error and fall through to proxy
-			failedNodeList[n.Name] = fmt.Errorf("direct connect failed (will attempt proxy): %s", err)
-		}
-		// TODO: why not try proxy and direct in same method?
-		// TODO: will this skip collecting one endpoint if most of them passed the above direct collection?
-		// retrieve node summary via proxy
-		err := proxyNodeFetch(nd, config)
+		err := retrieveNodeData(nd, config, nodeSource, n)
 		if err != nil {
-			failedNodeList[n.Name] = fmt.Errorf("proxy connect failed: %s", err)
+			failedNodeList[n.Name] = fmt.Errorf("node metrics retrieval problem occurred: %v", err)
 		}
 	}
 
@@ -225,20 +232,13 @@ type nodeFetchData struct {
 	containersRequest []byte
 }
 
-// directNodeFetch retrieves node stats directly from the node api
-func directNodeFetch(nodeSource NodeSource, config KubeAgentConfig, n *v1.Node, nd nodeFetchData) error {
-	ip, port, err := nodeSource.NodeAddress(n)
+// setupDirectNodeAPI retrieves node stats directly from the node api
+func setupDirectNodeAPI(ns NodeSource, config KubeAgentConfig, n *v1.Node, nd nodeFetchData) (directNode, error) {
+	ip, port, err := ns.NodeAddress(n)
 	if err != nil {
-		return fmt.Errorf("problem getting node address: %s", err)
+		return directNode{}, fmt.Errorf("problem getting node address: %s", err)
 	}
-	d := directNodeEndpoints(ip, port)
-	return retrieveNodeData(nd, config.NodeClient, config.MetricsEndpoints, Direct, d)
-}
-
-// proxyNodeFetch retrieves node data via the proxy api
-func proxyNodeFetch(nd nodeFetchData, config KubeAgentConfig) error {
-	proxy := proxyEndpoints(config.ClusterHostURL, nd.nodeName)
-	return retrieveNodeData(nd, config.InClusterClient, config.MetricsEndpoints, Proxy, proxy)
+	return directNodeEndpoints(ip, port), nil
 }
 
 type nodeAPI interface {
@@ -267,7 +267,7 @@ func (p proxyAPI) mCAdvisor() string {
 	return fmt.Sprintf("%s/api/v1/nodes/%s/proxy/metrics/cadvisor", p.clusterHostURL, p.nodeName)
 }
 
-func proxyEndpoints(clusterHostURL, nodeName string) proxyAPI {
+func setupProxyAPI(clusterHostURL, nodeName string) proxyAPI {
 	return proxyAPI{
 		clusterHostURL: clusterHostURL,
 		nodeName:       nodeName,
@@ -318,42 +318,75 @@ func (s sourceName) cadvisorMetrics() string {
 	return fmt.Sprintf("%s-cadvisor_metrics-%s", s.prefix, s.nodeName)
 }
 
-// retrieveNodeData fetches summary and container data from the node
-func retrieveNodeData(nd nodeFetchData, c raw.Client, mask EndpointMask, method Connection, api nodeAPI) error {
+// retrieveNodeData fetches summary and container data for the node
+func retrieveNodeData(nd nodeFetchData, config KubeAgentConfig, ns NodeSource, n v1.Node) error {
+	connectionMethods := connectionOptions(config, n, nd, ns)
 	source := sourceName{
 		prefix:   nd.prefix,
 		nodeName: nd.nodeName,
 	}
-	var err error
-
-	if mask.Available(NodeStatsSummaryEndpoint, method) {
-		// fetch stats/summary data
-		log.Debug("Fetching data from /stats/summary endpoint")
-		_, err = c.GetRawEndPoint(http.MethodGet, source.summary(), nd.workDir, api.statsSummary(), nil, true)
-		if err != nil {
-			return err
+	var (
+		statsSummaryFetched    bool
+		metricsCadvisorFetched bool
+		statsContainerFetched  bool
+	)
+	// if we receive an error after the max number of retries when attempting to hit an endpoint that
+	// we had previously verified to work, we fail and assume the node is unreachable at this time
+	for _, cm := range connectionMethods {
+		if !statsSummaryFetched && config.NodeMetrics.Available(NodeStatsSummaryEndpoint, cm.ConnType) {
+			log.Debugf("Fetching data from /stats/summary endpoint via %s connection", cm.FriendlyName)
+			_, err := cm.client.GetRawEndPoint(http.MethodGet, source.summary(),
+				nd.workDir, cm.API.statsSummary(), nil, true)
+			if err != nil {
+				log.Debugf("Unable to fetch /stats/summary metrics: %v", err)
+				return err
+			}
+			statsSummaryFetched = true
+		}
+		if !metricsCadvisorFetched && config.NodeMetrics.Available(NodeCadvisorEndpoint, cm.ConnType) {
+			// fetch metrics/CAdvisor data
+			log.Debugf("Fetching data from /metrics/cadvisor endpoint via %s connection", cm.FriendlyName)
+			_, err := cm.client.GetRawEndPoint(http.MethodGet, source.cadvisorMetrics(),
+				nd.workDir, cm.API.mCAdvisor(), nil, true)
+			if err != nil {
+				log.Debugf("Unable to fetch /metrics/cadvisor metrics: %v", err)
+				return err
+			}
+			metricsCadvisorFetched = true
+		}
+		if !statsContainerFetched && config.NodeMetrics.Available(NodeContainerEndpoint, cm.ConnType) {
+			// fetch container details
+			log.Debugf("Fetching data from /stats/container endpoint via %s connection", cm.FriendlyName)
+			_, err := cm.client.GetRawEndPoint(
+				http.MethodPost, source.container(), nd.workDir, cm.API.statsContainer(),
+				nd.containersRequest, true)
+			if err != nil {
+				log.Debugf("Unable to fetch /stats/container metrics: %v", err)
+				return err
+			}
+			statsContainerFetched = true
 		}
 	}
+	return nil
+}
 
-	if mask.Available(NodeCadvisorEndpoint, method) {
-		// fetch metrics/mCAdvisor data
-		log.Debug("Fetching data from /metrics/cadvisor endpoint")
-		_, err = c.GetRawEndPoint(http.MethodGet, source.cadvisorMetrics(), nd.workDir, api.mCAdvisor(), nil, true)
+// connectionOptions returns the connection methods that are allowed for this node based on config
+// settings and cluster composition
+func connectionOptions(config KubeAgentConfig, n v1.Node, nd nodeFetchData, ns NodeSource) []ConnectionMethod {
+	connectionMethods := make([]ConnectionMethod, 1)
+	// The config shouldn't allow direct connection if Fargate nodes were
+	// found in the cluster at startup, but check again here to be safe.
+	if !config.ForceKubeProxy && !isFargateNode(n) {
+		directAPI, err := setupDirectNodeAPI(ns, config, &n, nd)
 		if err != nil {
-			return err
+			log.Debugf("Unable to attempt direct connection to node %s: %v", nd.nodeName, err)
+		} else {
+			connectionMethods = append(connectionMethods, ConnectionMethod{Direct, directAPI, config.NodeClient, direct})
 		}
 	}
-
-	if mask.Available(NodeContainerEndpoint, method) {
-		// fetch container details
-		log.Debug("Fetching data from /stats/container endpoint")
-		_, err = c.GetRawEndPoint(
-			http.MethodPost, source.container(), nd.workDir, api.statsContainer(), nd.containersRequest, true)
-		if err != nil {
-			return err
-		}
-	}
-	return err
+	proxyAPI := setupProxyAPI(config.ClusterHostURL, nd.nodeName)
+	connectionMethods = append(connectionMethods, ConnectionMethod{Proxy, proxyAPI, config.InClusterClient, proxy})
+	return connectionMethods
 }
 
 //ensureNodeSource validates connectivity to the kubelet metrics endpoints.
@@ -391,68 +424,63 @@ func ensureNodeSource(config KubeAgentConfig) (KubeAgentConfig, error) {
 	if allowDirectConnect(config, nodes) {
 		// test node direct connectivity
 		d := directNodeEndpoints(ip, port)
-		success, err := testNodeConn(config, &nodeHTTPClient, Direct, d.statsSummary(),
+		success, err := checkEndpointConnections(config, &nodeHTTPClient, Direct, d.statsSummary(),
 			d.statsContainer(), d.mCAdvisor())
 		if err != nil {
 			return config, err
 		}
 		if success {
-			// TODO: nuke nodeRM and just check endpoints directly
-			config.nodeRetrievalMethod.AddMethod(Direct)
 			return config, nil
 		}
 	}
 
 	// test node connectivity via kube-proxy
-	p := proxyEndpoints(config.ClusterHostURL, firstNode.Name)
-	success, err := testNodeConn(config, &config.HTTPClient, Proxy, p.statsSummary(),
+	p := setupProxyAPI(config.ClusterHostURL, firstNode.Name)
+	success, err := checkEndpointConnections(config, &config.HTTPClient, Proxy, p.statsSummary(),
 		p.statsContainer(), p.mCAdvisor())
 	if err != nil {
 		return config, err
 	}
 	if success {
-		config.NodeClient = raw.Client{}
-		config.nodeRetrievalMethod.AddMethod(Proxy)
-	}
-	// TODO: add a more readable method?
-	if config.nodeRetrievalMethod > 0 {
 		return config, nil
 	}
-	config.nodeRetrievalMethod = Unreachable
+
 	config.RetrieveNodeSummaries = false
-	return config, fmt.Errorf("unable to retrieve node metrics. Please verify RBAC roles: %v", err)
+	return config, fmt.Errorf("unable to retrieve required set of node metrics via direct or proxy connection")
 }
 
-func testNodeConn(config KubeAgentConfig, client *http.Client, method Connection, nodeStatSum,
+func checkEndpointConnections(config KubeAgentConfig, client *http.Client, method Connection, nodeStatSum,
 	containerStats, cadvisorMetrics string) (success bool, err error) {
 	ns, _, err := util.TestHTTPConnection(client, nodeStatSum, http.MethodGet, config.BearerToken, 0, false)
 	if err != nil {
 		return false, err
 	}
-	log.Infof("Availability of the /stats/summary endpoint is: %v", ns)
-	config.MetricsEndpoints.SetAvailable(NodeStatsSummaryEndpoint, method, ns)
+	log.Infof("/stats/summary endpoint available via %s connection? %v", method, ns)
+	config.NodeMetrics.SetAvailable(NodeStatsSummaryEndpoint, method, ns)
 
 	cm, _, err := util.TestHTTPConnection(client, cadvisorMetrics, http.MethodGet, config.BearerToken, 0, false)
 	if err != nil {
 		return false, err
 	}
-	log.Infof("Availability of the /metrics/cadvisor endpoint is: %v", cm)
-	config.MetricsEndpoints.SetAvailable(NodeCadvisorEndpoint, method, cm)
+	log.Infof("/metrics/cadvisor endpoint available via %s connection? %v", method, cm)
+	config.NodeMetrics.SetAvailable(NodeCadvisorEndpoint, method, cm)
 
 	cs, _, err := util.TestHTTPConnection(client, containerStats, http.MethodPost, config.BearerToken, 0, false)
 	if err != nil {
 		return false, err
 	}
-	log.Infof("Availability of the /stats/container endpoint is: %v", cs)
-	config.MetricsEndpoints.SetAvailable(NodeContainerEndpoint, method, cs)
+	log.Infof("/stats/container endpoint available via %s connection? %v", method, cs)
+	config.NodeMetrics.SetAvailable(NodeContainerEndpoint, method, cs)
 
-	con := MetricsRequirementsSatisfied(config, cm, cs)
+	con := metricsRequirementsSatisfied(config, cm, cs, method)
 	return ns && con, nil
 }
 
-// MetricsRequirementsSatisfied returns whether all of the desired containers metrics endpoints were reached
-func MetricsRequirementsSatisfied(config KubeAgentConfig, cm, cs bool) bool {
-	if config.RetrieveAllConStats {
+// metricsRequirementsSatisfied returns whether all of the desired containers metrics endpoints were reached
+func metricsRequirementsSatisfied(config KubeAgentConfig, cm, cs bool, method Connection) bool {
+	// Don't fail if the connection method is proxy and one of the endpoints
+	// is still missing, as this is expected in 1.18+
+	if config.GetAllConStats && method.HasMethod(Direct) {
 		return cm && cs
 	}
 	return cm || cs

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -153,12 +153,12 @@ func TestEnsureNodeSource(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeStatsSummaryEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected /stats/summary to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeStatsSummaryEndpoint), err)
 			return
 		}
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeCadvisorEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected /metrics/cadvisor to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeCadvisorEndpoint), err)
 			return
 		}
@@ -216,22 +216,22 @@ func TestEnsureNodeSource(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeStatsSummaryEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected /stats/summary to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeStatsSummaryEndpoint), err)
 			return
 		}
 		if !ka.NodeMetrics.DirectAllowed(kubernetes.NodeStatsSummaryEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected /stats/summary to allow direct method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeStatsSummaryEndpoint), err)
 			return
 		}
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeCadvisorEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected /metrics/cadvisor to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeCadvisorEndpoint), err)
 			return
 		}
 		if !ka.NodeMetrics.DirectAllowed(kubernetes.NodeContainerEndpoint) {
-			t.Errorf("Expected direct method but got %v: %v",
+			t.Errorf("Expected /stats/container to allow direct method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeContainerEndpoint), err)
 			return
 		}
@@ -265,7 +265,7 @@ func TestEnsureNodeSource(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeStatsSummaryEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected /stats/summary to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeStatsSummaryEndpoint), err)
 			return
 		}
@@ -275,7 +275,7 @@ func TestEnsureNodeSource(t *testing.T) {
 			return
 		}
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeCadvisorEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected metrics/cadvisor to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeCadvisorEndpoint), err)
 			return
 		}
@@ -310,7 +310,7 @@ func TestEnsureNodeSource(t *testing.T) {
 		ka, err := kubernetes.EnsureNodeSource(ka)
 
 		if !ka.NodeMetrics.ProxyAllowed(kubernetes.NodeStatsSummaryEndpoint) {
-			t.Errorf("Expected proxy method but got %v: %v",
+			t.Errorf("Expected stats/summary to allow proxy method but got %v: %v",
 				ka.NodeMetrics.Options(kubernetes.NodeStatsSummaryEndpoint), err)
 			return
 		}

--- a/retrieval/raw/raw_endpoint.go
+++ b/retrieval/raw/raw_endpoint.go
@@ -66,7 +66,7 @@ func (c *Client) GetRawEndPoint(method, sourceName string,
 			return filename, nil
 		}
 		if verbose {
-			log.Warnf("%v URL: %s using %s -- retrying: %v", err, URL, method, i+1)
+			log.Warnf("%v URL: %s -- retrying: %v", err, URL, i+1)
 		}
 	}
 	return filename, err

--- a/retrieval/raw/raw_endpoint.go
+++ b/retrieval/raw/raw_endpoint.go
@@ -66,7 +66,7 @@ func (c *Client) GetRawEndPoint(method, sourceName string,
 			return filename, nil
 		}
 		if verbose {
-			log.Warnf("%v URL: %s retrying: %v", err, URL, i+1)
+			log.Warnf("%v URL: %s using %s -- retrying: %v", err, URL, method, i+1)
 		}
 	}
 	return filename, err

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.4.1"
+var VERSION = "1.5.0"


### PR DESCRIPTION
#### What does this PR do?
Currently the metrics agent assumes that all node endpoints will be able to use the same type of connection (direct or proxy), and if one endpoint fails on the direct connection attempt, all endpoints fall back to using a proxy connection.

In some clusters the new `metrics/cadvisor` endpoint is not accessible directly, so this PR simplifies the connection logic to set the allowed connection on each endpoint rather than cascading through each connection type for all endpoints.

#### Where should the reviewer start?
Take a look at the Connection type and the EndpointMask changes

#### How should this be manually tested?
This has been tested on several clusters with varying permissions configurations

#### Any background context you want to provide?

After this change, the use of separate clients for proxy and direct is starting to seem like an unecessary complexity, but in the interest of keeping this PR small I didn't tackle that part.

This change would also enable us to avoid needing to disable direct connection on clusters that have a single Fargate node in them, as we could handle connection type at the node level rather than at the cluster level.

#### What are the relevant Github Issues?
#90 
#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)