### PR TITLE
Add e2e test for k8s 1.20 and update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ version:
 release-version:
 	@echo $(RELEASE-VERSION)
 
+test-e2e-1.20: container-build install-tools
+	$(call TEST_KUBERNETES,v1.20.0,$(PREFIX),$(VERSION))
+
 test-e2e-1.19: container-build install-tools
 	$(call TEST_KUBERNETES,v1.19.0,$(PREFIX),$(VERSION))
 
@@ -120,6 +123,6 @@ test-e2e-1.16: container-build install-tools
 test-e2e-1.15: container-build install-tools
 	$(call TEST_KUBERNETES,v1.15.0,$(PREFIX),$(VERSION))
 
-test-e2e-all: test-e2e-1.19 test-e2e-1.18 test-e2e-1.17 test-e2e-1.16 test-e2e-1.15
+test-e2e-all: test-e2e-1.20 test-e2e-1.19 test-e2e-1.18 test-e2e-1.17 test-e2e-1.16 test-e2e-1.15
 
 .PHONY: test version

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Every 10 minutes the metrics agent creates a tarball of the gathered metrics and
 
 ### Supported Versions
 
-#### 1.19 and below
+#### 1.20 and below
 
-Kubernetes versions 1.19 and below are supported by the metrics agent.
+Kubernetes versions 1.20 and below are supported by the metrics agent.
 
 #### 1.18 
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "1.6"
+var VERSION = "1.7"


### PR DESCRIPTION
#### What does this PR do?
Adds a make command to the makefile for running an end-to-end test with 1.20 K8s version. Also updates the README with the newly supported version.

#### Where should the reviewer start?
Anywhere

#### How should this be manually tested?
Run the make command: `make test-e2e-1.20`

#### Any background context you want to provide?
Nope

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?
N/A

#### Developer Done List

- [ ] Tests Added/Updated
- [X] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [X] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)