### PR TITLE
Add k8s 1.22 makefile e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,9 @@ version:
 release-version:
 	@echo $(RELEASE-VERSION)
 
+test-e2e-1.22: container-build install-tools
+	$(call TEST_KUBERNETES,v1.22.0,$(PREFIX),$(VERSION))
+
 test-e2e-1.21.1: container-build install-tools
 	$(call TEST_KUBERNETES,v1.21.1,$(PREFIX),$(VERSION))
 
@@ -117,6 +120,6 @@ test-e2e-1.19: container-build install-tools
 test-e2e-1.18: container-build install-tools
 	$(call TEST_KUBERNETES,v1.18.0,$(PREFIX),$(VERSION))
 
-test-e2e-all: test-e2e-1.21.1 test-e2e-1.20 test-e2e-1.19 test-e2e-1.18
+test-e2e-all: test-e2e-1.22 test-e2e-1.21.1 test-e2e-1.20 test-e2e-1.19 test-e2e-1.18
 
 .PHONY: test version

--- a/testdata/e2e/e2e.sh
+++ b/testdata/e2e/e2e.sh
@@ -33,7 +33,8 @@ setup_kind() {
   fi
 
   sleep 2
-  
+  kubectl version
+
     i=0
     until [ $i -ge 5 ]
     do


### PR DESCRIPTION
#### What does this PR do?
Adds the 1.22 e2e test to the Makefile and adds more info on test logs.
#### Where should the reviewer start?
MakeFile
#### How should this be manually tested?
Run `make test-e2e-1.22` and `make test-e2e-all`
#### Any background context you want to provide?
Part of 1.22 work
#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)