### PR TITLE
feat/149-arm-images: update Dockerfile to allow for multi-arch images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 ARCH?=amd64
+DOCKER_PLATFORMS := linux/amd64,linux/arm64
 EXECUTABLES = go
 EXEC_CHECK := $(foreach exec,$(EXECUTABLES), \
 	$(if $(shell which $(exec)),some string,$(error "No $(exec) in PATH.")))
@@ -47,7 +48,8 @@ build:
 	GOARCH=$(ARCH) CGO_ENABLED=0 go build -o metrics-agent main.go
 
 container-build:
-	docker build --build-arg golang_version=$(GOLANG_VERSION) \
+	docker buildx build --build-arg golang_version=$(GOLANG_VERSION) \
+	--platform ${DOCKER_PLATFORMS} --pull --push \
 	--build-arg package=$(PKG) \
 	--build-arg application=$(APPLICATION) \
 	-t $(PREFIX)/metrics-agent:$(VERSION) -f deploy/docker/Dockerfile .

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -8,10 +8,16 @@ ARG application
 WORKDIR /go/src/${package}/
 
 # Build source code
+ARG TARGETOS
+ARG TARGETARCH
+ARG TARGETVARIANT
 ENV CGO_ENABLED=0
-ENV GOOS=linux
+ENV GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOARM=${TARGETVARIANT}
 COPY . /go/src/${package}
-RUN go build
+RUN export GOARM=$(echo "${GOARM}" | cut -c2-) && \
+    go build
 
 FROM alpine:3.13
 ARG package

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "2.5"
+var VERSION = "2.6"


### PR DESCRIPTION
#### What does this PR do?
This PR will update the `Dockerfile` in order to build, and create, multi-arch images. This should enable users to run this `metric-agent` within ARM architecture.
#### Where should the reviewer start?
The reviewer should start with the `Dockerfile` and `Makefile`. That is where most of the changes are located.
#### How should this be manually tested?
This can be manually tested. I am not sure if there is any automation setup for releasing new binaries and images.
#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?
No current Docker image is supporting ARM: https://hub.docker.com/r/cloudability/metrics-agent/tags
<img width="1679" alt="Screen Shot 2022-03-14 at 6 32 08 PM" src="https://user-images.githubusercontent.com/4017416/158271747-a828c233-eb4a-4cbd-8916-dc859ab7e823.png">

#### What are the relevant Github Issues?
This should fix and close this issue: #149
#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)