### PR TITLE
Update Alpine to v3.14 and Deploy Multi-Arch Image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Master
+name: Deploy
 
 on:
   push:
@@ -8,31 +8,30 @@ on:
 
 jobs:
   deploy:
+    name: Build and Deploy
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
-      - uses: actions/checkout@v2
-      - name: build docker container
-        run: make -e container-build
-      - name: docker tag
-        if: github.ref == 'refs/heads/master'
-        run: make docker-tag
-      - name: docker beta tag
-        if: github.ref == 'refs/heads/beta'
-        run: make docker-tag-beta
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: push to dockerhub
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.16'
+      - uses: actions/checkout@v2
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker Build Master and Push
+        # If pushing to the master branch, we want to correctly tag the builds
+        # in docker-hub with the new master makefile command
         if: github.ref == 'refs/heads/master'
-        run: make dockerhub-push
-      - name: push to beta dockerhub
+        run: make container-build-master
+      - name: Docker Build Beta and Push
+        # If pushing to the beta branch, we want to correctly tag the builds
+        # in docker-hub with the new beta makefile command
         if: github.ref == 'refs/heads/beta'
-        run: make dockerhub-push-beta
+        run: make container-build-beta
 
   slackFinish:
     name: Notify Finish
@@ -48,4 +47,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
+
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,7 @@ jobs:
         run: make test
 
   test_e2e:
-    name: Test E2E
+    name: Test E2E AMD
     needs: build
     runs-on: ubuntu-18.04
     steps:
@@ -46,8 +46,9 @@ jobs:
         with:
           go-version: '1.16'
       - uses: actions/checkout@v2
-      - name: run e2e tests
+      - name: run e2e AMD tests
         run: make test-e2e-all
+
 
   slackFinish:
     name: Notify Finish

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@ Every 10 minutes the metrics agent creates a tarball of the gathered metrics and
 
 #### 1.22 and below
 
-Kubernetes versions 1.22 and below are supported by the metrics agent.
+Kubernetes versions 1.22 and below are supported by the metrics agent on AWS, GCP and Azure cloud services.
+
+#### Architectures
+
+On AWS, both AMD64 and ARM architectures are supported.
+
+### Unsupported Configurations
+
+Cloudability Metrics Agent currently does not support OpenShift, Rancher or On Prem clusters.
 
 ### Configuration Options
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV GOOS=linux
 COPY . /go/src/${package}
 RUN go build
 
-FROM alpine:3.13
+FROM alpine:3.14
 ARG package
 ARG application
 

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "2.5"
+var VERSION = "2.6"


### PR DESCRIPTION
#### What does this PR do?
Updates Alpine version to 3.14 and updates the build to build multiarchitectural images and github workflows to use the buildx push functionality instead of separate workflow steps.

#### Where should the reviewer start?
Makefile changes to set up the new workflow.

#### How should this be manually tested?
This has been tested on all available versions of EKS, AKS and GCP clusters and architectures.  EKS has tested both AMD and ARM64 architectures.

#### Any background context you want to provide?
This will build three images but will deploy a manifest that will be tagged with the metrics-agent:latest tag and version tag.  Docker in the metrics agent will use the manifest to pull the image it needs to work on the appropriate architecture.

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?
#149 

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)