### PR TITLE
Increase metric collection upload frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The metrics-agent collects allocation metrics from a Kubernetes cluster system a
 
 By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and directly from each node in the cluster it is running in. Additionally it will pull metrics from [Heapster](https://github.com/kubernetes/heapster) if found running in the kube-system namespace.  An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml).
 
-Every 10 minutes the metrics agent creates a tarball of the gathered metrics and uploads to an Amazon Web Service S3 bucket. This process requires outbound connections to https://metrics-collector.cloudability.com/, to obtain a pre-signed URL, and https://cldy-cake-pipeline.s3.amazonaws.com/ to upload the data. If the metrics agent is deployed behind a firewall, these addresses should be added to the outbound allow list.
+On every metric poll, the metrics agent creates a tarball of the gathered metrics and uploads them via a post request. This process requires outbound connections to https://metrics-collector.cloudability.com/, to obtain a pre-signed URL, and https://cldy-cake-pipeline.s3.amazonaws.com/ to upload the data. If the metrics agent is deployed behind a firewall, these addresses should be added to the outbound allow list.
 
 ### Supported Versions
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -133,8 +133,12 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 	// run , sleep etc..
 	doneChan := make(chan bool)
 
-	// set send frequency to be less than that of poll frequency
-	sendChan := time.NewTicker(time.Duration(config.PollInterval/2) * time.Second)
+	// set send frequency to be less than that of poll frequency, floor of once a minute
+	sendFrequency := time.Duration(config.PollInterval/2) * time.Second
+	if sendFrequency < time.Minute {
+		sendFrequency = time.Minute
+	}
+	sendChan := time.NewTicker(sendFrequency)
 
 	pollChan := time.NewTicker(time.Duration(config.PollInterval) * time.Second)
 

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -82,7 +82,6 @@ type KubeAgentConfig struct {
 	NodeMetrics           EndpointMask
 }
 
-const uploadInterval time.Duration = 10
 const retryCount uint = 10
 const DefaultCollectionRetry = 1
 
@@ -134,7 +133,8 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 	// run , sleep etc..
 	doneChan := make(chan bool)
 
-	sendChan := time.NewTicker(uploadInterval * time.Minute)
+	// set send frequency to be less than that of poll frequency
+	sendChan := time.NewTicker(time.Duration(config.PollInterval/2) * time.Second)
 
 	pollChan := time.NewTicker(time.Duration(config.PollInterval) * time.Second)
 


### PR DESCRIPTION
#### What does this PR do?
Increases the upload frequency of the metrics-agent from once every 10 minutes to be less than the configured poll frequency.
This ensures that only one metric collection is uploaded at a time, and allows the Apptio backend to decrease it's processing time per file.

#### Where should the reviewer start?

#### How should this be manually tested?
Run it, make sure that metrics populate still.

#### Any background context you want to provide?
Currently there are a handful of users uploading very large metric collection sets. This will improve Apptio's ability to deliver data back to customers in a more timely manner.

#### What are the relevant Github Issues?
N/A
#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)