### PR TITLE
Service Account Token Refresh for http Clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,15 @@ container-build-single-platform:
 	--build-arg application=$(APPLICATION) \
 	-t $(PREFIX)/metrics-agent:$(VERSION)-$(PLATFORM_TAG) -f deploy/docker/Dockerfile .
 
+# Specify the repository you would like to send the single-architecture image to after building
+container-build-single-repository:
+	@read -p "Enter the repository name you want to send this image to: " REPOSITORY; \
+	docker build --platform $(PLATFORM) \
+	--build-arg golang_version=$(GOLANG_VERSION) \
+	--build-arg package=$(PKG) \
+	--build-arg application=$(APPLICATION) \
+	-t $$REPOSITORY/metrics-agent:$(VERSION) -f deploy/docker/Dockerfile . --push
+
 # Specify the repository you would like to send the multi-architectural image to after building.
 container-build-repository:
 	@read -p "Enter the repository name you want to send this image to: " REPOSITORY; \

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ container-build-single-platform:
 # Specify the repository you would like to send the single-architecture image to after building
 container-build-single-repository:
 	@read -p "Enter the repository name you want to send this image to: " REPOSITORY; \
-	docker build --platform $(PLATFORM) \
+	docker buildx build --platform $(PLATFORM) \
 	--build-arg golang_version=$(GOLANG_VERSION) \
 	--build-arg package=$(PKG) \
 	--build-arg application=$(APPLICATION) \

--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -18,4 +18,4 @@ version: 0.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.0
+appVersion: 1.2.1

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -253,11 +253,9 @@ func (ka KubeAgentConfig) collectMetrics(ctx context.Context, config KubeAgentCo
 		log.Warnf("Couldn't read auth token defined in %q: %v", config.BearerTokenPath, err)
 	} else {
 		// update token for kubeAgent and InClusterClient
-		log.Warnf("Token found! Old token %q", config.BearerToken)
 		config.BearerToken = token
 		config.InClusterClient.BearerToken = token
 		config.NodeClient.BearerToken = token
-		log.Warnf("Updated token %q", config.BearerToken)
 	}
 
 	//create metric sample directory

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -448,6 +448,9 @@ func createClusterConfig(config KubeAgentConfig) (KubeAgentConfig, error) {
 			config.Key = thisConfig.KeyFile
 			config.TLSClientConfig = thisConfig.TLSClientConfig
 			config.Clientset, err = kubernetes.NewForConfig(thisConfig)
+			// this should be validated again
+			config.BearerToken = thisConfig.BearerToken
+			config.BearerTokenPath = thisConfig.BearerTokenFile
 			return config, err
 		}
 		log.Warn(
@@ -474,6 +477,7 @@ func createClusterConfig(config KubeAgentConfig) (KubeAgentConfig, error) {
 	config.Key = thisConfig.KeyFile
 	config.TLSClientConfig.CAFile = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 	config.BearerToken = thisConfig.BearerToken
+	config.BearerTokenPath = thisConfig.BearerTokenFile
 	if config.Namespace == "" {
 		config.Namespace = "cloudability"
 	}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -253,9 +253,11 @@ func (ka KubeAgentConfig) collectMetrics(ctx context.Context, config KubeAgentCo
 		log.Warnf("Couldn't read auth token defined in %q: %v", config.BearerTokenPath, err)
 	} else {
 		// update token for kubeAgent and InClusterClient
+		log.Warnf("Token found! Old token %q", config.BearerToken)
 		config.BearerToken = token
 		config.InClusterClient.BearerToken = token
 		config.NodeClient.BearerToken = token
+		log.Warnf("Updated token %q", config.BearerToken)
 	}
 
 	//create metric sample directory

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -880,8 +880,8 @@ func fetchDiagnostics(ctx context.Context, clientset kubernetes.Interface, names
 }
 
 // getBearerToken reads the service account token
-func getBearerToken(authTokenPath string) (string, error) {
-	token, err := ioutil.ReadFile(authTokenPath)
+func getBearerToken(bearerTokenPath string) (string, error) {
+	token, err := ioutil.ReadFile(bearerTokenPath)
 	if err != nil {
 		return "", errors.New("could not read bearer token from file")
 	}

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -241,6 +241,7 @@ func newKubeAgent(ctx context.Context, config KubeAgentConfig) KubeAgentConfig {
 	return config
 }
 
+//nolint gocyclo
 func (ka KubeAgentConfig) collectMetrics(ctx context.Context, config KubeAgentConfig,
 	clientset kubernetes.Interface, nodeSource NodeSource) (rerr error) {
 
@@ -496,7 +497,7 @@ func updateConfig(ctx context.Context, config KubeAgentConfig) (KubeAgentConfig,
 		return updatedConfig, err
 	}
 	updatedConfig.InClusterClient = raw.NewClient(updatedConfig.HTTPClient, config.Insecure,
-		config.BearerToken, config.CollectionRetryLimit)
+		config.BearerToken, config.BearerTokenPath, config.CollectionRetryLimit)
 
 	updatedConfig.clusterUID, err = getNamespaceUID(ctx, updatedConfig.Clientset, "default")
 	if err != nil {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -249,7 +249,9 @@ func (ka KubeAgentConfig) collectMetrics(ctx context.Context, config KubeAgentCo
 	// refresh client token before each collection
 	token, err := getBearerToken(config.BearerTokenPath)
 	if err != nil {
-		log.Warnf("Warning: %s. If cluster version >=1.21 this token must be updated", err)
+		log.Warnf("Warning: Unable to update service account token for cloudability-metrics-agent. If this"+
+			" token is not refreshed in clusters >=1.21, the metrics-agent won't be able to collect data once"+
+			" token is expired. %s", err)
 	}
 
 	config.BearerToken = token

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -249,7 +249,7 @@ func (ka KubeAgentConfig) collectMetrics(ctx context.Context, config KubeAgentCo
 	// refresh client token before each collection
 	token, err := getBearerToken(config.BearerTokenPath)
 	if err != nil {
-		return err
+		log.Warnf("Warning: %s. If cluster version >=1.21 this token must be updated", err)
 	}
 
 	config.BearerToken = token

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -247,18 +247,18 @@ func (ka KubeAgentConfig) collectMetrics(ctx context.Context, config KubeAgentCo
 
 	sampleStartTime := time.Now().UTC()
 
-	// refresh client token before each collection?
+	// refresh client token before each collection
 	token, err := getBearerToken(config.BearerTokenPath)
 	if err != nil {
 		log.Warnf("Couldn't read auth token defined in %q: %v", config.BearerTokenPath, err)
 	} else {
-		// update token for kubeAgent and InClusterClient
+		// update tokens
 		config.BearerToken = token
 		config.InClusterClient.BearerToken = token
 		config.NodeClient.BearerToken = token
 	}
 
-	//create metric sample directory
+	// create metric sample directory
 	msd, metricSampleDir, err := createMSD(config.msExportDirectory.Name(), sampleStartTime)
 	if err != nil {
 		return err
@@ -448,7 +448,6 @@ func createClusterConfig(config KubeAgentConfig) (KubeAgentConfig, error) {
 			config.Key = thisConfig.KeyFile
 			config.TLSClientConfig = thisConfig.TLSClientConfig
 			config.Clientset, err = kubernetes.NewForConfig(thisConfig)
-			// this should be validated again
 			config.BearerToken = thisConfig.BearerToken
 			config.BearerTokenPath = thisConfig.BearerTokenFile
 			return config, err

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -277,6 +277,7 @@ func TestCollectMetrics(t *testing.T) {
 		HeapsterURL:           ts.URL,
 		Insecure:              true,
 		BearerToken:           "",
+		BearerTokenPath:       "",
 		RetrieveNodeSummaries: true,
 		ForceKubeProxy:        false,
 		GetAllConStats:        true,
@@ -289,6 +290,12 @@ func TestCollectMetrics(t *testing.T) {
 	// set Direct as option as well
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
 	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Direct, true)
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Error(err)
+	}
+	ka.BearerTokenPath = wd + "/testdata/mockToken"
 
 	ka.InClusterClient = raw.NewClient(ka.HTTPClient, ka.Insecure, ka.BearerToken, ka.BearerTokenPath, 0)
 	fns := NewClientsetNodeSource(cs)

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -141,7 +141,7 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 			ClusterHostURL:        ts.URL,
 			HeapsterURL:           ts.URL,
 			HTTPClient:            client,
-			InClusterClient:       raw.NewClient(client, true, "", 0),
+			InClusterClient:       raw.NewClient(client, true, "", "", 0),
 		}
 
 		var err error
@@ -290,7 +290,7 @@ func TestCollectMetrics(t *testing.T) {
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
 	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Direct, true)
 
-	ka.InClusterClient = raw.NewClient(ka.HTTPClient, ka.Insecure, ka.BearerToken, 0)
+	ka.InClusterClient = raw.NewClient(ka.HTTPClient, ka.Insecure, ka.BearerToken, ka.BearerTokenPath, 0)
 	fns := NewClientsetNodeSource(cs)
 
 	t.Run("Ensure that a collection occurs", func(t *testing.T) {

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -323,7 +323,8 @@ func ensureNodeSource(ctx context.Context, config KubeAgentConfig) (KubeAgentCon
 
 	clientSetNodeSource := NewClientsetNodeSource(config.Clientset)
 
-	nodeClient := raw.NewClient(nodeHTTPClient, true, config.BearerToken, config.CollectionRetryLimit)
+	nodeClient := raw.NewClient(nodeHTTPClient, true, config.BearerToken, config.BearerTokenPath,
+		config.CollectionRetryLimit)
 
 	config.NodeClient = nodeClient
 

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -354,8 +354,8 @@ func TestEnsureNodeSource(t *testing.T) {
 			GetAllConStats: true,
 			NodeMetrics:    EndpointMask{},
 			// just populate some dummy fields here to ensure neither client gets unset
-			InClusterClient: raw.NewClient(http.Client{}, true, "token", 0),
-			NodeClient:      raw.NewClient(http.Client{}, true, "token", 0),
+			InClusterClient: raw.NewClient(http.Client{}, true, "token", "", 0),
+			NodeClient:      raw.NewClient(http.Client{}, true, "token", "", 0),
 		}
 
 		ka, err := ensureNodeSource(context.TODO(), ka)
@@ -657,6 +657,7 @@ func setupTestNodeDownloaderClients(ts *httptest.Server,
 	rc := raw.NewClient(
 		c,
 		true,
+		"",
 		"",
 		retries,
 	)

--- a/kubernetes/testdata/mockToken
+++ b/kubernetes/testdata/mockToken
@@ -1,0 +1,1 @@
+mymocktoken1234

--- a/retrieval/raw/raw_endpoint.go
+++ b/retrieval/raw/raw_endpoint.go
@@ -18,21 +18,21 @@ import (
 
 //Client defines an HTTP Client
 type Client struct {
-	HTTPClient   *http.Client
-	insecure     bool
-	BearerToken  string
-	kubeletToken string
-	kubeletPath  string
-	retries      uint
+	HTTPClient      *http.Client
+	insecure        bool
+	BearerToken     string
+	BearerTokenPath string
+	retries         uint
 }
 
 //NewClient creates a new raw.Client
-func NewClient(HTTPClient http.Client, insecure bool, bearerToken string, retries uint) Client {
+func NewClient(HTTPClient http.Client, insecure bool, bearerToken, bearerTokenPath string, retries uint) Client {
 	return Client{
-		HTTPClient:  &HTTPClient,
-		insecure:    insecure,
-		BearerToken: bearerToken,
-		retries:     retries,
+		HTTPClient:      &HTTPClient,
+		insecure:        insecure,
+		BearerToken:     bearerToken,
+		BearerTokenPath: bearerTokenPath,
+		retries:         retries,
 	}
 }
 

--- a/retrieval/raw/raw_endpoint.go
+++ b/retrieval/raw/raw_endpoint.go
@@ -18,10 +18,12 @@ import (
 
 //Client defines an HTTP Client
 type Client struct {
-	HTTPClient  *http.Client
-	insecure    bool
-	bearerToken string
-	retries     uint
+	HTTPClient   *http.Client
+	insecure     bool
+	BearerToken  string
+	kubeletToken string
+	kubeletPath  string
+	retries      uint
 }
 
 //NewClient creates a new raw.Client
@@ -29,7 +31,7 @@ func NewClient(HTTPClient http.Client, insecure bool, bearerToken string, retrie
 	return Client{
 		HTTPClient:  &HTTPClient,
 		insecure:    insecure,
-		bearerToken: bearerToken,
+		BearerToken: bearerToken,
 		retries:     retries,
 	}
 }
@@ -42,8 +44,8 @@ func (c *Client) createRequest(method, url string, body io.Reader) (*http.Reques
 		return nil, err
 	}
 
-	if c.bearerToken != "" {
-		request.Header.Add("Authorization", "bearer "+c.bearerToken)
+	if c.BearerToken != "" {
+		request.Header.Add("Authorization", "bearer "+c.BearerToken)
 	}
 
 	return request, err

--- a/retrieval/raw/raw_endpoint_test.go
+++ b/retrieval/raw/raw_endpoint_test.go
@@ -21,6 +21,7 @@ func TestGetRawEndPoint(t *testing.T) {
 			*httpClient,
 			true,
 			"",
+			"",
 			2,
 		)
 
@@ -61,6 +62,7 @@ func TestGetRawEndPoint(t *testing.T) {
 			*httpClient,
 			true,
 			"",
+			"",
 			2,
 		)
 
@@ -86,6 +88,7 @@ func TestGetRawEndPoint(t *testing.T) {
 		client := NewClient(
 			*httpClient,
 			true,
+			"",
 			"",
 			2,
 		)

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "2.8"
+var VERSION = "2.9"


### PR DESCRIPTION
#### What does this PR do?
This PR addresses a service account token expiry issue for the kubeAgents http clients that communicate with the k8s api-server. These changes update the bearer (service account) tokens of the kubeAgent http clients every time node metrics are collected.
#### Where should the reviewer start?
kubernetes.go
#### How should this be manually tested?
This has been tested in a test cluster in version 1.22 eks.
#### Any background context you want to provide?
The Kubernetes feature "BoundServiceAccountTokenVolume" graduated to beta and is now enabled on 1.21+ clusters which improves security of service account tokens. This release refreshes the service account token that the metrics-agent's clients use every time node metrics are collected. This prevents the metrics-agent from using stale tokens. For more information see the [Kubernetes official release statement](https://kubernetes.io/blog/2021/04/08/kubernetes-1-21-release-announcement/) and [EKS documentation](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.21).
#### What picture best describes this PR (optional but encouraged)?
![image](https://user-images.githubusercontent.com/86271298/171507013-2e6b5cc7-58bb-472a-9f5a-137d42711990.png)
#### What are the relevant Github Issues?
n/a
#### Developer Done List

- [x] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)