### PR TITLE
Fix Helm Chart Versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ On AWS, both AMD64 and ARM architectures are supported.
 
 ### Deploying with Helm
 
-Instructions for deploying the metrics-agent using Helm can be found [here](https://cloudability.github.io/metrics-agent/).
+Instructions for deploying the metrics-agent using Helm can be found [here](https://cloudability.github.io/metrics-agent/). For helm versioning this repository follows the [simple 1-1 versioning](https://codefresh.io/docs/docs/new-helm/helm-best-practices/#simple-1-1-versioning) strategy where the chart version is in snyc with the actual application.
 
 ### Unsupported Configurations
 

--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.2.2
+version: 2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.2.1
+appVersion: 2.9

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -19,7 +19,7 @@ pollInterval: 180
 
 image:
   name: cloudability/metrics-agent
-  tag: latest
+  tag: 2.9
   pullPolicy: Always
 
 imagePullSecrets: []


### PR DESCRIPTION
#### What does this PR do?
Updates the helm chart versioning to match current metrics-agent version
#### Where should the reviewer start?
Chart.yaml
#### How should this be manually tested?
Already tested deploying the chart locally
#### Any background context you want to provide?
Nope
#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?
https://github.com/cloudability/metrics-agent/issues/178
#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)