### PR TITLE
Parallel node collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,4 +147,13 @@ test-e2e-1.18: container-build-single-platform install-tools
 
 test-e2e-all: test-e2e-1.22 test-e2e-1.21.1 test-e2e-1.20 test-e2e-1.19 test-e2e-1.18
 
+container-build-single-repository:
+	@read -p "Enter the repository name you want to send this image to: " REPOSITORY; \
+	docker buildx build --platform $(PLATFORM) \
+	--build-arg golang_version=$(GOLANG_VERSION) \
+	--build-arg package=$(PKG) \
+	--build-arg application=$(APPLICATION) \
+	-t $$REPOSITORY/metrics-agent:$(VERSION) -f deploy/docker/Dockerfile . --push
+
+
 .PHONY: test version

--- a/Makefile
+++ b/Makefile
@@ -147,13 +147,4 @@ test-e2e-1.18: container-build-single-platform install-tools
 
 test-e2e-all: test-e2e-1.22 test-e2e-1.21.1 test-e2e-1.20 test-e2e-1.19 test-e2e-1.18
 
-container-build-single-repository:
-	@read -p "Enter the repository name you want to send this image to: " REPOSITORY; \
-	docker buildx build --platform $(PLATFORM) \
-	--build-arg golang_version=$(GOLANG_VERSION) \
-	--build-arg package=$(PKG) \
-	--build-arg application=$(APPLICATION) \
-	-t $$REPOSITORY/metrics-agent:$(VERSION) -f deploy/docker/Dockerfile . --push
-
-
 .PHONY: test version

--- a/README.md
+++ b/README.md
@@ -32,25 +32,26 @@ Cloudability Metrics Agent currently does not support OpenShift, Rancher or On P
 
 ### Configuration Options
 
-| Environment Variable                    | Description                                                                                                                          |
-| --------------------------------------- |:------------------------------------------------------------------------------------------------------------------------------------:|
-| CLOUDABILITY_API_KEY                    | Required: Cloudability api key                                                                                                       |
-| CLOUDABILITY_CLUSTER_NAME               | Required: The cluster name to be used for the cluster the agent is running in.                                                       |
-| CLOUDABILITY_POLL_INTERVAL              | Optional: The interval (Seconds) to poll metrics. Default: 180                                                                       |
-| CLOUDABILITY_HEAPSTER_URL               | Optional: Only required if heapster is not deployed as a service in your cluster or is only accessable via a specific URL.           |
-| CLOUDABILITY_OUTBOUND_PROXY             | Optional: The URL of an outbound HTTP/HTTPS proxy for the agent to use (eg: http://x.x.x.x:8080). The URL must contain the scheme prefix (http:// or https://)  |
-| CLOUDABILITY_OUTBOUND_PROXY_AUTH        | Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password |
-| CLOUDABILITY_OUTBOUND_PROXY_INSECURE    | Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False |
-| CLOUDABILITY_INSECURE                   | Optional: When true, does not verify certificates when making TLS connections. Default: False|
-| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES    | Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True|
-| CLOUDABILITY_GET_ALL_CONTAINER_STATS    | Optional: When true, attempts to collect from both the stats/container and metrics/cadvisor endpoints, which may result in a larger metrics payload. When False, only collects first successful endpoint. Default: False|
-| CLOUDABILITY_FORCE_KUBE_PROXY           | Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False|
-| CLOUDABILITY_COLLECT_HEAPSTER_EXPORT    | Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True|
-| CLOUDABILITY_COLLECTION_RETRY_LIMIT     | Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1|
-| CLOUDABILITY_NAMESPACE                  | Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`|
-| CLOUDABILITY_LOG_FORMAT                 | Optional: Format for log output (JSON,PLAIN) Default: PLAIN|
-| CLOUDABILITY_LOG_LEVEL                  | Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`|
-| CLOUDABILITY_SCRATCH_DIR                | Optional: Temporary directory that metrics will be written to. If set, must assure that the directory exists and that the user agent UID 1000 has read/write access to the folder. Default: `/tmp`|
+| Environment Variable                           |                                                                                                       Description                                                                                                        |
+|------------------------------------------------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| CLOUDABILITY_API_KEY                           |                                                                                              Required: Cloudability api key                                                                                              |
+| CLOUDABILITY_CLUSTER_NAME                      |                                                                      Required: The cluster name to be used for the cluster the agent is running in.                                                                      |
+| CLOUDABILITY_POLL_INTERVAL                     |                                                                              Optional: The interval (Seconds) to poll metrics. Default: 180                                                                              |
+| CLOUDABILITY_HEAPSTER_URL                      |                                                Optional: Only required if heapster is not deployed as a service in your cluster or is only accessable via a specific URL.                                                |
+| CLOUDABILITY_OUTBOUND_PROXY                    |                              Optional: The URL of an outbound HTTP/HTTPS proxy for the agent to use (eg: http://x.x.x.x:8080). The URL must contain the scheme prefix (http:// or https://)                              |
+| CLOUDABILITY_OUTBOUND_PROXY_AUTH               |           Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password           |
+| CLOUDABILITY_OUTBOUND_PROXY_INSECURE           |                                                           Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False                                                            |
+| CLOUDABILITY_INSECURE                          |                                                              Optional: When true, does not verify certificates when making TLS connections. Default: False                                                               |
+| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES           |                                    Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True                                    |
+| CLOUDABILITY_GET_ALL_CONTAINER_STATS           | Optional: When true, attempts to collect from both the stats/container and metrics/cadvisor endpoints, which may result in a larger metrics payload. When False, only collects first successful endpoint. Default: False |
+| CLOUDABILITY_FORCE_KUBE_PROXY                  |                                            Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False                                             |
+| CLOUDABILITY_COLLECT_HEAPSTER_EXPORT           |                                        Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True                                         |
+| CLOUDABILITY_COLLECTION_RETRY_LIMIT            |                                                       Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1                                                        |
+| CLOUDABILITY_NAMESPACE                         |                  Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`                   |
+| CLOUDABILITY_LOG_FORMAT                        |                                                                               Optional: Format for log output (JSON,PLAIN) Default: PLAIN                                                                                |
+| CLOUDABILITY_LOG_LEVEL                         |                                                                     Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`                                                                     |
+| CLOUDABILITY_SCRATCH_DIR                       |            Optional: Temporary directory that metrics will be written to. If set, must assure that the directory exists and that the user agent UID 1000 has read/write access to the folder. Default: `/tmp`            |
+| CLOUDABILITY_NUMBER_OF_CONCURRENT_NODE_POLLERS |                                                             Optional: Number of goroutines that are created to poll node metrics in parallel. Default: `10`                                                              |
 
 ```sh
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Cloudability Metrics Agent currently does not support OpenShift, Rancher or On P
 | CLOUDABILITY_LOG_FORMAT                        |                                                                               Optional: Format for log output (JSON,PLAIN) Default: PLAIN                                                                                |
 | CLOUDABILITY_LOG_LEVEL                         |                                                                     Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`                                                                     |
 | CLOUDABILITY_SCRATCH_DIR                       |            Optional: Temporary directory that metrics will be written to. If set, must assure that the directory exists and that the user agent UID 1000 has read/write access to the folder. Default: `/tmp`            |
-| CLOUDABILITY_NUMBER_OF_CONCURRENT_NODE_POLLERS |                                                             Optional: Number of goroutines that are created to poll node metrics in parallel. Default: `10`                                                              |
+| CLOUDABILITY_NUMBER_OF_CONCURRENT_NODE_POLLERS |                                                             Optional: Number of goroutines that are created to poll node metrics in parallel. Default: `100`                                                             |
 
 ```sh
 

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -135,8 +135,8 @@ func init() {
 	kubernetesCmd.PersistentFlags().IntVar(
 		&config.ConcurrentPollers,
 		"number_of_concurrent_node_pollers",
-		10,
-		"Number of concurrent goroutines created when polling node data. Default 10",
+		100,
+		"Number of concurrent goroutines created when polling node data. Default 100",
 	)
 
 	//nolint gas

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -132,6 +132,12 @@ func init() {
 		"/tmp",
 		"Directory metrics will be written to",
 	)
+	kubernetesCmd.PersistentFlags().IntVar(
+		&config.ConcurrentPollers,
+		"number_of_concurrent_node_pollers",
+		10,
+		"Number of concurrent goroutines created when polling node data. Default 10",
+	)
 
 	//nolint gas
 	_ = viper.BindPFlag("api_key", kubernetesCmd.PersistentFlags().Lookup("api_key"))
@@ -151,6 +157,8 @@ func init() {
 	_ = viper.BindPFlag("namespace", kubernetesCmd.PersistentFlags().Lookup("namespace"))
 	_ = viper.BindPFlag("collect_heapster_export", kubernetesCmd.PersistentFlags().Lookup("collect_heapster_export"))
 	_ = viper.BindPFlag("scratch_dir", kubernetesCmd.PersistentFlags().Lookup("scratch_dir"))
+	//nolint lll
+	_ = viper.BindPFlag("number_of_concurrent_node_pollers", kubernetesCmd.PersistentFlags().Lookup("number_of_concurrent_node_pollers"))
 
 	viper.SetEnvPrefix("cloudability")
 	viper.AutomaticEnv()
@@ -172,6 +180,7 @@ func init() {
 		Key:                   viper.GetString("key_file"),
 		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
 		GetAllConStats:        viper.GetBool("get_all_container_stats"),
+		ConcurrentPollers:     viper.GetInt("number_of_concurrent_node_pollers"),
 		ForceKubeProxy:        viper.GetBool("force_kube_proxy"),
 		Namespace:             viper.GetString("namespace"),
 		ScratchDir:            viper.GetString("scratch_dir"),

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -66,6 +66,7 @@ type KubeAgentConfig struct {
 	UseInClusterConfig    bool
 	CollectHeapsterExport bool
 	PollInterval          int
+	ConcurrentPollers     int
 	CollectionRetryLimit  uint
 	failedNodeList        map[string]error
 	AgentStartTime        time.Time

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -114,6 +114,7 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 			CollectHeapsterExport: false,
 			Clientset:             cs,
 			NodeMetrics:           EndpointMask{},
+			ConcurrentPollers:     10,
 		}
 		config, err := ensureMetricServicesAvailable(context.TODO(), config)
 		if err == nil {
@@ -142,6 +143,7 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 			HeapsterURL:           ts.URL,
 			HTTPClient:            client,
 			InClusterClient:       raw.NewClient(client, true, "", "", 0),
+			ConcurrentPollers:     10,
 		}
 
 		var err error
@@ -281,6 +283,7 @@ func TestCollectMetrics(t *testing.T) {
 		RetrieveNodeSummaries: true,
 		ForceKubeProxy:        false,
 		GetAllConStats:        true,
+		ConcurrentPollers:     10,
 	}
 	ka.NodeMetrics = EndpointMask{}
 	// set Proxy method available

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -106,10 +106,9 @@ func downloadNodeData(ctx context.Context, prefix string, config KubeAgentConfig
 		return nil, fmt.Errorf("error occurred requesting container statistics: %v", err)
 	}
 
-	log.Infoln("Starting node collection for loop")
+	log.Debugln("Starting node collection loop")
 
 	var wg sync.WaitGroup
-	var counter = 0
 
 	// creates a max number of concurrent goroutines that are allowed
 	limiter := make(chan struct{}, config.ConcurrentPollers)
@@ -120,7 +119,6 @@ func downloadNodeData(ctx context.Context, prefix string, config KubeAgentConfig
 
 		wg.Add(1)
 		go func(currentNode v1.Node) {
-			counter++
 			if currentNode.Spec.ProviderID == "" {
 				errMessage := "Node ProviderID is not set which may be because the node is running in a " +
 					"self managed environment, and this may cause inconsistent gathering of metrics data."
@@ -136,7 +134,6 @@ func downloadNodeData(ctx context.Context, prefix string, config KubeAgentConfig
 				ClusterHostURL:    config.ClusterHostURL,
 				containersRequest: containersRequest,
 			}
-			log.Infof("RetrieveNodeData for nodeFetchData: %+v Which is node number: %d", nd, counter)
 			err := retrieveNodeData(nd, config, nodeSource, currentNode)
 			if err != nil {
 				failedNodeList[currentNode.Name] = fmt.Errorf("node metrics retrieval problem occurred: %v", err)
@@ -146,9 +143,9 @@ func downloadNodeData(ctx context.Context, prefix string, config KubeAgentConfig
 		}(n)
 	}
 
-	log.Infoln("Currently Waiting for all node data to be gathered")
+	log.Debugln("Currently Waiting for all node data to be gathered")
 	wg.Wait()
-	log.Infof("All nodes data has been gathered, no longer waiting")
+	log.Debugln("All nodes data has been gathered, no longer waiting")
 
 	return failedNodeList, nil
 }

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -28,7 +28,8 @@ func TestFetchEndpoint(t *testing.T) {
 		// Direct method is enabled
 		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
 		config := KubeAgentConfig{
-			NodeMetrics: mask,
+			NodeMetrics:       mask,
+			ConcurrentPollers: 10,
 		}
 		// Use Direct method for connection
 		cm := ConnectionMethod{
@@ -58,7 +59,8 @@ func TestFetchEndpoint(t *testing.T) {
 		mask := EndpointMask{}
 		mask.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
 		config := KubeAgentConfig{
-			NodeMetrics: mask,
+			NodeMetrics:       mask,
+			ConcurrentPollers: 10,
 		}
 		cm := ConnectionMethod{
 			ConnType: Direct,
@@ -86,7 +88,8 @@ func TestFetchEndpoint(t *testing.T) {
 		// only proxy is available
 		mask.SetAvailability(NodeCadvisorEndpoint, Proxy, true)
 		config := KubeAgentConfig{
-			NodeMetrics: mask,
+			NodeMetrics:       mask,
+			ConcurrentPollers: 10,
 		}
 		// try to fetch via Direct
 		cm := ConnectionMethod{
@@ -169,6 +172,7 @@ func TestEnsureNodeSource(t *testing.T) {
 		HTTPClient:           http.Client{},
 		CollectionRetryLimit: 0,
 		GetAllConStats:       true,
+		ConcurrentPollers:    10,
 		NodeMetrics:          EndpointMask{},
 	}
 
@@ -201,6 +205,7 @@ func TestEnsureNodeSource(t *testing.T) {
 			HTTPClient:           http.Client{},
 			CollectionRetryLimit: 0,
 			GetAllConStats:       false,
+			ConcurrentPollers:    10,
 			NodeMetrics:          EndpointMask{},
 		}
 
@@ -237,9 +242,10 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 		}
 
 		ka, err := ensureNodeSource(context.TODO(), ka)
@@ -278,9 +284,10 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 		}
 
 		_, err := ensureNodeSource(context.TODO(), ka)
@@ -304,9 +311,10 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 		}
 
 		ka, err := ensureNodeSource(context.TODO(), ka)
@@ -350,9 +358,10 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 			// just populate some dummy fields here to ensure neither client gets unset
 			InClusterClient: raw.NewClient(http.Client{}, true, "token", "", 0),
 			NodeClient:      raw.NewClient(http.Client{}, true, "token", "", 0),
@@ -400,9 +409,10 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 		}
 
 		ka, err := ensureNodeSource(context.TODO(), ka)
@@ -433,9 +443,10 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 		}
 		ka, err := ensureNodeSource(context.TODO(), ka)
 
@@ -460,10 +471,11 @@ func TestEnsureNodeSource(t *testing.T) {
 				InsecureSkipVerify: true,
 			},
 			}},
-			ClusterHostURL: "https://" + ts.Listener.Addr().String(),
-			GetAllConStats: true,
-			ForceKubeProxy: true,
-			NodeMetrics:    EndpointMask{},
+			ClusterHostURL:    "https://" + ts.Listener.Addr().String(),
+			GetAllConStats:    true,
+			ForceKubeProxy:    true,
+			ConcurrentPollers: 10,
+			NodeMetrics:       EndpointMask{},
 		}
 		ka, err := ensureNodeSource(context.TODO(), ka)
 		if ka.NodeMetrics.DirectAllowed(NodeStatsSummaryEndpoint) {
@@ -668,6 +680,7 @@ func setupTestNodeDownloaderClients(ts *httptest.Server,
 		ClusterHostURL:        "https://" + ts.Listener.Addr().String(),
 		RetrieveNodeSummaries: true,
 		GetAllConStats:        true,
+		ConcurrentPollers:     10,
 		CollectionRetryLimit:  retries,
 	}
 	ka.NodeMetrics = EndpointMask{}


### PR DESCRIPTION
#### What does this PR do?
Includes a new feature that allows for node polling parallelism. The metrics-agent polls metrics from each node every polling interval and now this polling is done concurrently. There is a new env variable that can be set called CLOUDABILITY_NUMBER_OF_CONCURRENT_NODE_POLLERS which is the max number of concurrent pollers at a time. The current default is set to 100.
#### Where should the reviewer start?
nodecollection.go
#### How should this be manually tested?
Tested on cluster and mock tested large cluster sizes
#### Any background context you want to provide?
This is a beta release
#### What picture best describes this PR (optional but encouraged)?
![image](https://user-images.githubusercontent.com/86271298/173696160-fec1d1e3-cad4-4d9c-8e72-1bf0fe46d119.png)

#### What are the relevant Github Issues?
none
#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)