### PR TITLE
Adding the possibility to use a secret already present in Kubernetes

### DIFF
--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -39,7 +39,7 @@ spec:
             - name: "CLOUDABILITY_API_KEY"
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "metrics-agent.fullname" . }}
+                  name: {{- if not .Values.secretName }} {{ include "metrics-agent.fullname" . }} {{- else }} {{ .Values.secretName }} {{- end }}
                   key: CLOUDABILITY_API_KEY
             - name: CLOUDABILITY_CLUSTER_NAME
               value: {{ .Values.clusterName }}

--- a/charts/metrics-agent/templates/secret.yaml
+++ b/charts/metrics-agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   CLOUDABILITY_API_KEY: {{ .Values.apiKey | b64enc | quote }}
+{{- end }}

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -6,11 +6,14 @@
 nameOverride: ""
 fullnameOverride: ""
 
-# apiKey is REQUIRED.
+# apiKey or secretName is REQUIRED.
 # You must generate a template to get your apiKey.
 # In the Cloudability app, go to Insights -> Containers, then click
 # the provisioning cluster button that will take you through our provisioning workflow.
 apiKey: ""
+# name of the secret already stored in k8s conaining CLOUDABILITY_API_KEY
+secretName: ""
+
 # clusterName is REQUIRED.
 # The cluster name to be used for the cluster the agent runs in.
 clusterName: ""


### PR DESCRIPTION
#### What does this PR do?
Makes the creation of the secret from the helm chart optional by allowing the user to specify secretName.

#### Where should the reviewer start?
Check the helm chart content

#### How should this be manually tested?
Deploy without specifying secretName to check retrocompatibility.
Upload the secret manually with a custom name and specify that name in secretName

#### Any background context you want to provide?
I have the necessity to manage the secrets outside the repo invoking the helm chart and not to have it in code.

#### What picture best describes this PR (optional but encouraged)?
Flexibility in the usage of secrets in order to increase security.

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)