### PR TITLE
Update README, Add K8s 1.23 e2e testing, fix deploy GH actions to run when version incremented

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,13 +2,13 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - master
-      - beta
-
+    paths:
+      - 'version/version.go'
 jobs:
   deploy:
     name: Build and Deploy
+    # only build/deploy for beta and master branches
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/beta'
     runs-on: ubuntu-18.04
     steps:
       - name: Login to DockerHub

--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,9 @@ version:
 release-version:
 	@echo $(RELEASE-VERSION)
 
+test-e2e-1.23: container-build-single-platform install-tools
+	$(call TEST_KUBERNETES,v1.23.0,$(PREFIX),$(VERSION)-$(PLATFORM_TAG))
+
 test-e2e-1.22: container-build-single-platform install-tools
 	$(call TEST_KUBERNETES,v1.22.0,$(PREFIX),$(VERSION)-$(PLATFORM_TAG))
 
@@ -142,9 +145,6 @@ test-e2e-1.20: container-build-single-platform install-tools
 test-e2e-1.19: container-build-single-platform install-tools
 	$(call TEST_KUBERNETES,v1.19.0,$(PREFIX),$(VERSION)-$(PLATFORM_TAG))
 
-test-e2e-1.18: container-build-single-platform install-tools
-	$(call TEST_KUBERNETES,v1.18.0,$(PREFIX),$(VERSION)-$(PLATFORM_TAG))
-
-test-e2e-all: test-e2e-1.22 test-e2e-1.21.1 test-e2e-1.20 test-e2e-1.19 test-e2e-1.18
+test-e2e-all: test-e2e-1.23 test-e2e-1.22 test-e2e-1.21.1 test-e2e-1.20 test-e2e-1.19
 
 .PHONY: test version

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Every 10 minutes the metrics agent creates a tarball of the gathered metrics and
 
 ### Supported Versions
 
-#### 1.22 and below
+#### 1.23 and below
 
-Kubernetes versions 1.22 and below are supported by the metrics agent on AWS, GCP and Azure cloud services.
+Kubernetes versions 1.23 and below are supported by the metrics agent on AWS, GCP and Azure cloud services.
 
 #### Architectures
 


### PR DESCRIPTION
#### What does this PR do?
See title
#### Where should the reviewer start?
GH actions and makefile
#### How should this be manually tested?
Run make test-e2e-1.23
#### Any background context you want to provide?
Currently only tested on AKS 1.23 as this is the only provider with 1.23 support
#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)