### PR TITLE
Removal of Prometheus Data from metric agent uploads.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The metrics-agent collects allocation metrics from a Kubernetes cluster system a
 
 ## Kubernetes
 
-By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and directly from each node in the cluster it is running in. Additionally it will pull metrics from [Heapster](https://github.com/kubernetes/heapster) if found running in the kube-system namespace.  An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml).
+By default, the agent runs in a namespace named "cloudability" (see options below).  Once deployed, the agent will pull metrics from the Kubernetes API and directly from each node in the cluster it is running in.  An example kubernetes deployment can be found [here](deploy/kubernetes/cloudability-metrics-agent.yaml).
 
 Every 10 minutes the metrics agent creates a tarball of the gathered metrics and uploads to an Amazon Web Service S3 bucket. This process requires outbound connections to https://metrics-collector.cloudability.com/, to obtain a pre-signed URL, and https://cldy-cake-pipeline.s3.amazonaws.com/ to upload the data. If the metrics agent is deployed behind a firewall, these addresses should be added to the outbound allow list.
 
@@ -37,15 +37,11 @@ Cloudability Metrics Agent currently does not support OpenShift, Rancher or On P
 | CLOUDABILITY_API_KEY                 |                                                                                              Required: Cloudability api key                                                                                              |
 | CLOUDABILITY_CLUSTER_NAME            |                                                                      Required: The cluster name to be used for the cluster the agent is running in.                                                                      |
 | CLOUDABILITY_POLL_INTERVAL           |                                                                              Optional: The interval (Seconds) to poll metrics. Default: 180                                                                              |
-| CLOUDABILITY_HEAPSTER_URL            |                                                Optional: Only required if heapster is not deployed as a service in your cluster or is only accessable via a specific URL.                                                |
 | CLOUDABILITY_OUTBOUND_PROXY          |                              Optional: The URL of an outbound HTTP/HTTPS proxy for the agent to use (eg: http://x.x.x.x:8080). The URL must contain the scheme prefix (http:// or https://)                              |
 | CLOUDABILITY_OUTBOUND_PROXY_AUTH     |           Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password           |
 | CLOUDABILITY_OUTBOUND_PROXY_INSECURE |                                                           Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False                                                            |
 | CLOUDABILITY_INSECURE                |                                                              Optional: When true, does not verify certificates when making TLS connections. Default: False                                                               |
-| CLOUDABILITY_RETRIEVE_NODE_SUMMARIES |                                    Optional: When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True                                    |
-| CLOUDABILITY_GET_ALL_CONTAINER_STATS | Optional: When true, attempts to collect from both the stats/container and metrics/cadvisor endpoints, which may result in a larger metrics payload. When False, only collects first successful endpoint. Default: False |
 | CLOUDABILITY_FORCE_KUBE_PROXY        |                                            Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False                                             |
-| CLOUDABILITY_COLLECT_HEAPSTER_EXPORT |                                        Optional: When true, attempts to collect metrics from Heapster if available. When False, does not collect Heapster metrics. Default: True                                         |
 | CLOUDABILITY_COLLECTION_RETRY_LIMIT  |                                                       Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1                                                        |
 | CLOUDABILITY_NAMESPACE               |                  Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`                   |
 | CLOUDABILITY_LOG_FORMAT              |                                                                               Optional: Format for log output (JSON,PLAIN) Default: PLAIN                                                                                |
@@ -66,7 +62,6 @@ Flags:
       --api_key string                           Cloudability API Key - required
       --certificate_file string                  The path to a certificate file. - Optional
       --cluster_name string                      Kubernetes Cluster Name - required this must be unique to every cluster.
-      --heapster_override_url string             URL to connect to a running heapster instance. - optionally override the discovered Heapster URL.
       --collection_retry_limit uint              Number of times agent should attempt to gather metrics from each source upon a failure (default 1)
   -h, --help                                     help for kubernetes
       --insecure                                 When true, does not verify certificates when making TLS connections. Default: False
@@ -74,8 +69,7 @@ Flags:
       --outbound_proxy string                    Outbound HTTP/HTTPS proxy eg: http://x.x.x.x:8080. Must have a scheme prefix (http:// or https://) - Optional
       --outbound_proxy_auth string               Outbound proxy basic authentication credentials. Must defined in the form username:password - Optional
       --outbound_proxy_insecure                  When true, does not verify TLS certificates when using the outbound proxy. Default: False
-      --retrieve_node_summaries                  When true, collects metrics directly from each node in a cluster. When False, uses Heapster as the primary metrics source. Default: True
-      --get_all_container_stats                  When true, attempts to collect from both the stats/container and metrics/cadvisor endpoints, which may result in a larger metrics payload. Default: False
+
       --force_kube_proxy                         When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False
       --poll_interval int                        Time, in seconds, to poll the services infrastructure. Default: 180 (default 180)
       --namespace string                         The namespace which the agent runs in. Changing this is not recommended. (default `cloudability`)

--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.10.1
+version: 2.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.10.1
+appVersion: 2.11.0

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -19,7 +19,7 @@ pollInterval: 180
 
 image:
   name: cloudability/metrics-agent
-  tag: 2.10.1
+  tag: 2.11.0
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -103,12 +103,6 @@ func init() {
 		"When true, includes node summary metrics in metric collection.",
 	)
 	kubernetesCmd.PersistentFlags().BoolVar(
-		&config.GetAllConStats,
-		"get_all_container_stats",
-		false,
-		"When true, includes all available container metrics in metric collection. Default: False",
-	)
-	kubernetesCmd.PersistentFlags().BoolVar(
 		&config.ForceKubeProxy,
 		"force_kube_proxy",
 		false,
@@ -186,7 +180,6 @@ func init() {
 		Cert:                  viper.GetString("certificate_file"),
 		Key:                   viper.GetString("key_file"),
 		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
-		GetAllConStats:        viper.GetBool("get_all_container_stats"),
 		ConcurrentPollers:     viper.GetInt("number_of_concurrent_node_pollers"),
 		ForceKubeProxy:        viper.GetBool("force_kube_proxy"),
 		Namespace:             viper.GetString("namespace"),

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -42,12 +42,6 @@ func init() {
 		"",
 		"Kubernetes Cluster Name - required this must be unique to every cluster.",
 	)
-	kubernetesCmd.PersistentFlags().StringVar(
-		&config.HeapsterOverrideURL,
-		"heapster_override_url",
-		"",
-		"URL to connect to a running heapster instance. - optionally override the discovered Heapster URL.",
-	)
 	kubernetesCmd.PersistentFlags().IntVar(
 		&config.PollInterval,
 		"poll_interval",
@@ -97,22 +91,10 @@ func init() {
 		"When true, does not verify certificates when making TLS connections. Default: False",
 	)
 	kubernetesCmd.PersistentFlags().BoolVar(
-		&config.RetrieveNodeSummaries,
-		"retrieve_node_summaries",
-		true,
-		"When true, includes node summary metrics in metric collection.",
-	)
-	kubernetesCmd.PersistentFlags().BoolVar(
 		&config.ForceKubeProxy,
 		"force_kube_proxy",
 		false,
 		"When true, disables direct node connection and forces proxy use.",
-	)
-	kubernetesCmd.PersistentFlags().BoolVar(
-		&config.CollectHeapsterExport,
-		"collect_heapster_export",
-		true,
-		"When true, tries to fetch heapster metrics if present.",
 	)
 	kubernetesCmd.PersistentFlags().StringVar(
 		&config.Namespace,
@@ -169,8 +151,6 @@ func init() {
 	config = kubernetes.KubeAgentConfig{
 		APIKey:                viper.GetString("api_key"),
 		ClusterName:           viper.GetString("cluster_name"),
-		CollectHeapsterExport: viper.GetBool("collect_heapster_export"),
-		HeapsterOverrideURL:   viper.GetString("heapster_override_url"),
 		PollInterval:          viper.GetInt("poll_interval"),
 		CollectionRetryLimit:  viper.GetUint("collection_retry_limit"),
 		OutboundProxy:         viper.GetString("outbound_proxy"),
@@ -179,7 +159,6 @@ func init() {
 		Insecure:              viper.GetBool("insecure"),
 		Cert:                  viper.GetString("certificate_file"),
 		Key:                   viper.GetString("key_file"),
-		RetrieveNodeSummaries: viper.GetBool("retrieve_node_summaries"),
 		ConcurrentPollers:     viper.GetInt("number_of_concurrent_node_pollers"),
 		ForceKubeProxy:        viper.GetBool("force_kube_proxy"),
 		Namespace:             viper.GetString("namespace"),

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV GOOS=linux
 COPY . /go/src/${package}
 RUN go build
 
-FROM alpine:3.15
+FROM alpine:3.16
 ARG package
 ARG application
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -13,7 +13,7 @@ ENV GOOS=linux
 COPY . /go/src/${package}
 RUN go build
 
-FROM alpine:3.16
+FROM alpine:3.15
 ARG package
 ARG application
 

--- a/kubernetes/endpoint.go
+++ b/kubernetes/endpoint.go
@@ -57,9 +57,6 @@ type Endpoint string
 const (
 	// NodeStatsSummaryEndpoint the /stats/summary endpoint
 	NodeStatsSummaryEndpoint Endpoint = "/stats/summary"
-
-	// NodeContainerEndpoint the /stats/container endpoint
-	NodeContainerEndpoint Endpoint = "/stats/container"
 )
 
 // EndpointMask a map representing the currently active endpoints.

--- a/kubernetes/endpoint.go
+++ b/kubernetes/endpoint.go
@@ -60,9 +60,6 @@ const (
 
 	// NodeContainerEndpoint the /stats/container endpoint
 	NodeContainerEndpoint Endpoint = "/stats/container"
-
-	// NodeCadvisorEndpoint the /metrics/cadvisor endpoint
-	NodeCadvisorEndpoint Endpoint = "/metrics/cadvisor"
 )
 
 // EndpointMask a map representing the currently active endpoints.

--- a/kubernetes/endpoint_test.go
+++ b/kubernetes/endpoint_test.go
@@ -97,24 +97,24 @@ func TestConnection(t *testing.T) {
 func TestEndpointMask(t *testing.T) {
 	t.Run("endpoint should report Unreachable correctly", func(t *testing.T) {
 		mask := EndpointMask{}
-		if !mask.Unreachable(NodeContainerEndpoint) {
+		if !mask.Unreachable(NodeStatsSummaryEndpoint) {
 			t.Error("empty mask should return all endpoints as unreachable")
 		}
 
 		// Don't do this weird stuff, use mask.SetUnreachable
-		mask.SetAvailability(NodeContainerEndpoint, Unreachable, false)
-		if !mask.Unreachable(NodeContainerEndpoint) {
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Unreachable, false)
+		if !mask.Unreachable(NodeStatsSummaryEndpoint) {
 			t.Errorf("endpoint should have remained unreachable")
 		}
 
-		mask.SetAvailability(NodeContainerEndpoint, Proxy, true)
-		if !mask.ProxyAllowed(NodeContainerEndpoint) {
-			t.Errorf("should have proxy method set, instead got: %s", mask.Options(NodeContainerEndpoint))
+		mask.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)
+		if !mask.ProxyAllowed(NodeStatsSummaryEndpoint) {
+			t.Errorf("should have proxy method set, instead got: %s", mask.Options(NodeStatsSummaryEndpoint))
 		}
 
-		mask.SetUnreachable(NodeContainerEndpoint)
-		if !mask.Unreachable(NodeContainerEndpoint) {
-			t.Errorf("expected unreachable, got %s", mask.Options(NodeContainerEndpoint))
+		mask.SetUnreachable(NodeStatsSummaryEndpoint)
+		if !mask.Unreachable(NodeStatsSummaryEndpoint) {
+			t.Errorf("expected unreachable, got %s", mask.Options(NodeStatsSummaryEndpoint))
 		}
 	})
 	t.Run("endpoint should set availability correctly", func(t *testing.T) {

--- a/kubernetes/endpoint_test.go
+++ b/kubernetes/endpoint_test.go
@@ -97,24 +97,24 @@ func TestConnection(t *testing.T) {
 func TestEndpointMask(t *testing.T) {
 	t.Run("endpoint should report Unreachable correctly", func(t *testing.T) {
 		mask := EndpointMask{}
-		if !mask.Unreachable(NodeCadvisorEndpoint) {
+		if !mask.Unreachable(NodeContainerEndpoint) {
 			t.Error("empty mask should return all endpoints as unreachable")
 		}
 
 		// Don't do this weird stuff, use mask.SetUnreachable
-		mask.SetAvailability(NodeCadvisorEndpoint, Unreachable, false)
-		if !mask.Unreachable(NodeCadvisorEndpoint) {
+		mask.SetAvailability(NodeContainerEndpoint, Unreachable, false)
+		if !mask.Unreachable(NodeContainerEndpoint) {
 			t.Errorf("endpoint should have remained unreachable")
 		}
 
-		mask.SetAvailability(NodeCadvisorEndpoint, Proxy, true)
-		if !mask.ProxyAllowed(NodeCadvisorEndpoint) {
-			t.Errorf("should have proxy method set, instead got: %s", mask.Options(NodeCadvisorEndpoint))
+		mask.SetAvailability(NodeContainerEndpoint, Proxy, true)
+		if !mask.ProxyAllowed(NodeContainerEndpoint) {
+			t.Errorf("should have proxy method set, instead got: %s", mask.Options(NodeContainerEndpoint))
 		}
 
-		mask.SetUnreachable(NodeCadvisorEndpoint)
-		if !mask.Unreachable(NodeCadvisorEndpoint) {
-			t.Errorf("expected unreachable, got %s", mask.Options(NodeCadvisorEndpoint))
+		mask.SetUnreachable(NodeContainerEndpoint)
+		if !mask.Unreachable(NodeContainerEndpoint) {
+			t.Errorf("expected unreachable, got %s", mask.Options(NodeContainerEndpoint))
 		}
 	})
 	t.Run("endpoint should set availability correctly", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestEndpointMask(t *testing.T) {
 		}
 		// an endpoint with no methods available should be unreachable
 		if !mask.Unreachable(NodeStatsSummaryEndpoint) {
-			t.Errorf("expected unreachable, got %s", mask.Options(NodeCadvisorEndpoint))
+			t.Errorf("expected unreachable, got %s", mask.Options(NodeStatsSummaryEndpoint))
 		}
 	})
 	t.Run("should be able to set multiple connection methods per endpoint", func(t *testing.T) {

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -652,7 +652,6 @@ func ensureMetricServicesAvailable(ctx context.Context, config KubeAgentConfig) 
 		} else {
 			log.Infof("Node summaries connection method: %s", config.NodeMetrics.Options(NodeStatsSummaryEndpoint))
 			log.Infof("Node container metrics connection method: %s", config.NodeMetrics.Options(NodeContainerEndpoint))
-			log.Infof("Node cadvisor metrics connection method: %s", config.NodeMetrics.Options(NodeCadvisorEndpoint))
 		}
 	}
 	if config.CollectHeapsterExport {
@@ -780,7 +779,6 @@ func createAgentStatusMetric(workDir *os.File, config KubeAgentConfig, sampleSta
 	m.Values["outbound_proxy_url"] = config.OutboundProxyURL.String()
 	m.Values["stats_summary_retrieval_method"] = config.NodeMetrics.Options(NodeStatsSummaryEndpoint)
 	m.Values["stats_container_retrieval_method"] = config.NodeMetrics.Options(NodeContainerEndpoint)
-	m.Values["cadvisor_metrics_retrieval_method"] = config.NodeMetrics.Options(NodeCadvisorEndpoint)
 	m.Values["retrieve_node_summaries"] = strconv.FormatBool(config.RetrieveNodeSummaries)
 	m.Values["force_kube_proxy"] = strconv.FormatBool(config.ForceKubeProxy)
 	m.Values["number_of_concurrent_node_pollers"] = strconv.Itoa(config.ConcurrentPollers)

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -59,7 +59,6 @@ type KubeAgentConfig struct {
 	OutboundProxy         string
 	provisioningID        string
 	RetrieveNodeSummaries bool
-	GetAllConStats        bool
 	ForceKubeProxy        bool
 	Insecure              bool
 	OutboundProxyInsecure bool
@@ -198,11 +197,6 @@ func validateMetricCollectionConfig(config KubeAgentConfig) {
 	}
 	if config.RetrieveNodeSummaries {
 		log.Info("Primary metrics will be collected from each node.")
-		if config.GetAllConStats {
-			log.Info("All available node container metrics will be collected.")
-		} else {
-			log.Info("Minimum viable set of node container metrics will be collected.")
-		}
 	}
 	if config.RetrieveNodeSummaries && config.CollectHeapsterExport {
 		log.Debug("Collecting Heapster exports if found in cluster.")
@@ -651,7 +645,6 @@ func ensureMetricServicesAvailable(ctx context.Context, config KubeAgentConfig) 
 			log.Warnf(handleNodeSourceError(err))
 		} else {
 			log.Infof("Node summaries connection method: %s", config.NodeMetrics.Options(NodeStatsSummaryEndpoint))
-			log.Infof("Node container metrics connection method: %s", config.NodeMetrics.Options(NodeContainerEndpoint))
 		}
 	}
 	if config.CollectHeapsterExport {
@@ -778,7 +771,6 @@ func createAgentStatusMetric(workDir *os.File, config KubeAgentConfig, sampleSta
 	m.Values["provisioning_id"] = config.provisioningID
 	m.Values["outbound_proxy_url"] = config.OutboundProxyURL.String()
 	m.Values["stats_summary_retrieval_method"] = config.NodeMetrics.Options(NodeStatsSummaryEndpoint)
-	m.Values["stats_container_retrieval_method"] = config.NodeMetrics.Options(NodeContainerEndpoint)
 	m.Values["retrieve_node_summaries"] = strconv.FormatBool(config.RetrieveNodeSummaries)
 	m.Values["force_kube_proxy"] = strconv.FormatBool(config.ForceKubeProxy)
 	m.Values["number_of_concurrent_node_pollers"] = strconv.Itoa(config.ConcurrentPollers)

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -289,7 +289,6 @@ func TestCollectMetrics(t *testing.T) {
 	// set Proxy method available
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)
 	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Proxy, true)
-	ka.NodeMetrics.SetAvailability(NodeCadvisorEndpoint, Proxy, true)
 	// set Direct as option as well
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
 	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Direct, true)
@@ -317,9 +316,6 @@ func TestCollectMetrics(t *testing.T) {
 		nodeBaselineFiles := []string{}
 		nodeSummaryFiles := []string{}
 		expectedBaselineFiles := []string{
-			"baseline-cadvisor_metrics-node0.json",
-			"baseline-cadvisor_metrics-node1.json",
-			"baseline-cadvisor_metrics-node2.json",
 			"baseline-container-node0.json",
 			"baseline-container-node1.json",
 			"baseline-container-node2.json",
@@ -328,9 +324,6 @@ func TestCollectMetrics(t *testing.T) {
 			"baseline-summary-node2.json",
 		}
 		expectedSummaryFiles := []string{
-			"stats-cadvisor_metrics-node0.json",
-			"stats-cadvisor_metrics-node1.json",
-			"stats-cadvisor_metrics-node2.json",
 			"stats-container-node0.json",
 			"stats-container-node1.json",
 			"stats-container-node2.json",

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -96,7 +95,6 @@ func TestUpdateConfigurationForServices(t *testing.T) {
 }
 
 func TestEnsureMetricServicesAvailable(t *testing.T) {
-	t.Parallel()
 	t.Run("should return error if can't get node summaries", func(t *testing.T) {
 		cs := fake.NewSimpleClientset(
 			&v1.Node{
@@ -110,11 +108,9 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "node0", Namespace: v1.NamespaceDefault}},
 		)
 		config := KubeAgentConfig{
-			RetrieveNodeSummaries: true,
-			CollectHeapsterExport: false,
-			Clientset:             cs,
-			NodeMetrics:           EndpointMask{},
-			ConcurrentPollers:     10,
+			Clientset:         cs,
+			NodeMetrics:       EndpointMask{},
+			ConcurrentPollers: 10,
 		}
 		config, err := ensureMetricServicesAvailable(context.TODO(), config)
 		if err == nil {
@@ -136,14 +132,12 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 		ts := NewTestServer()
 		defer ts.Close()
 		config := KubeAgentConfig{
-			RetrieveNodeSummaries: true,
-			CollectHeapsterExport: false,
-			Clientset:             cs,
-			ClusterHostURL:        ts.URL,
-			HeapsterURL:           ts.URL,
-			HTTPClient:            client,
-			ConcurrentPollers:     10,
-			InClusterClient:       raw.NewClient(client, true, "", "", 0, false),
+			Clientset:         cs,
+			ClusterHostURL:    ts.URL,
+			HeapsterURL:       ts.URL,
+			HTTPClient:        client,
+			ConcurrentPollers: 10,
+			InClusterClient:   raw.NewClient(client, true, "", "", 0, false),
 		}
 
 		var err error
@@ -152,37 +146,6 @@ func TestEnsureMetricServicesAvailable(t *testing.T) {
 			t.Errorf("Unexpected error fetching node summaries: %s", err)
 		}
 	})
-}
-
-// nolint: dupl
-func TestUpdateConfigWithOverrideURLs(t *testing.T) {
-
-	t.Parallel()
-
-	t.Run("ensure that heapsterURL is set when Overridden Heapster URL argument is defined", func(t *testing.T) {
-		config := updateConfigWithOverrideURLs(KubeAgentConfig{
-			HeapsterOverrideURL: "https://heapster.availabile.here:443/",
-			Insecure:            false,
-		})
-		if config.HeapsterURL != config.HeapsterOverrideURL || config.Insecure {
-			t.Error(" HeapsterURL override URL set but not validated and set to heapsterURL ")
-		}
-
-	})
-
-	t.Run("ensure that heapsterURL is set to proxyPath when overridden Heapster URL is not defined", func(t *testing.T) {
-		config := updateConfigWithOverrideURLs(KubeAgentConfig{
-			HeapsterOverrideURL: "",
-			HeapsterProxyURL: url.URL{
-				Host: "http://localhost:8888/",
-				Path: "/api/v1/namespaces/default/services/heapster:8888/proxy/metrics"},
-		})
-		if config.HeapsterURL != config.HeapsterProxyURL.Host+config.HeapsterProxyURL.Path {
-			t.Error(" HeapsterURL is not set to proxyPath ")
-		}
-
-	})
-
 }
 
 func TestUpdateConfigWithOverrideNamespace(t *testing.T) {
@@ -271,18 +234,17 @@ func TestCollectMetrics(t *testing.T) {
 			version:     1.1,
 			versionInfo: sv,
 		},
-		Clientset:             cs,
-		HTTPClient:            http.Client{},
-		msExportDirectory:     tDir,
-		UseInClusterConfig:    false,
-		ClusterHostURL:        ts.URL,
-		HeapsterURL:           ts.URL,
-		Insecure:              true,
-		BearerToken:           "",
-		BearerTokenPath:       "",
-		RetrieveNodeSummaries: true,
-		ForceKubeProxy:        false,
-		ConcurrentPollers:     10,
+		Clientset:          cs,
+		HTTPClient:         http.Client{},
+		msExportDirectory:  tDir,
+		UseInClusterConfig: false,
+		ClusterHostURL:     ts.URL,
+		HeapsterURL:        ts.URL,
+		Insecure:           true,
+		BearerToken:        "",
+		BearerTokenPath:    "",
+		ForceKubeProxy:     false,
+		ConcurrentPollers:  10,
 	}
 	ka.NodeMetrics = EndpointMask{}
 	// set Proxy method available

--- a/kubernetes/kubernetes_test.go
+++ b/kubernetes/kubernetes_test.go
@@ -282,17 +282,13 @@ func TestCollectMetrics(t *testing.T) {
 		BearerTokenPath:       "",
 		RetrieveNodeSummaries: true,
 		ForceKubeProxy:        false,
-		GetAllConStats:        true,
 		ConcurrentPollers:     10,
 	}
 	ka.NodeMetrics = EndpointMask{}
 	// set Proxy method available
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)
-	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Proxy, true)
 	// set Direct as option as well
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
-	ka.NodeMetrics.SetAvailability(NodeContainerEndpoint, Direct, true)
-
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Error(err)
@@ -316,17 +312,11 @@ func TestCollectMetrics(t *testing.T) {
 		nodeBaselineFiles := []string{}
 		nodeSummaryFiles := []string{}
 		expectedBaselineFiles := []string{
-			"baseline-container-node0.json",
-			"baseline-container-node1.json",
-			"baseline-container-node2.json",
 			"baseline-summary-node0.json",
 			"baseline-summary-node1.json",
 			"baseline-summary-node2.json",
 		}
 		expectedSummaryFiles := []string{
-			"stats-container-node0.json",
-			"stats-container-node1.json",
-			"stats-container-node2.json",
 			"stats-summary-node0.json",
 			"stats-summary-node1.json",
 			"stats-summary-node2.json",

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -22,6 +22,16 @@ import (
 	"k8s.io/client-go/util/retry"
 )
 
+type nodeError string
+
+func (err nodeError) Error() string {
+	return string(err)
+}
+
+const (
+	FatalNodeError = nodeError("unable to retrieve required set of node metrics via direct or proxy connection")
+)
+
 // NodeSource is an interface to get a list of Nodes
 type NodeSource interface {
 	GetReadyNodes(ctx context.Context) ([]v1.Node, error)
@@ -365,8 +375,7 @@ func ensureNodeSource(ctx context.Context, config KubeAgentConfig) (KubeAgentCon
 		return config, nil
 	}
 
-	config.RetrieveNodeSummaries = false
-	return config, fmt.Errorf("unable to retrieve required set of node metrics via direct or proxy connection")
+	return config, FatalNodeError
 }
 
 func checkEndpointConnections(config KubeAgentConfig, client *http.Client, method Connection,

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -194,7 +194,7 @@ func TestEnsureNodeSource(t *testing.T) {
 		}
 	})
 
-	t.Run("Ensure failure to direct node source test without metrics endpoint", func(t *testing.T) {
+	t.Run("Ensure successful connection to direct node source test without metrics endpoint", func(t *testing.T) {
 		returnCodes := []int{200, 404}
 		ts := launchTLSTestServer(returnCodes)
 		defer ts.Close()
@@ -268,9 +268,8 @@ func TestEnsureNodeSource(t *testing.T) {
 		}
 	})
 
-	t.Run("do not expect failure if container metrics unavailable", func(t *testing.T) {
+	t.Run("Do not expect failure if container metrics unavailable", func(t *testing.T) {
 		// stats/summary will succeed, but cadvisor and containers will fail both times
-		// Metrics collection is incomplete without at least one
 		directConnectionAttempts := []int{200, 400, 404}
 		proxyConnectionAttempts := []int{200, 400, 404}
 		directConnectionReturnCodes := append(directConnectionAttempts, proxyConnectionAttempts...)

--- a/kubernetes/nodecollection_test.go
+++ b/kubernetes/nodecollection_test.go
@@ -612,13 +612,12 @@ func setupTestNodeDownloaderClients(ts *httptest.Server,
 		false,
 	)
 	ka := KubeAgentConfig{
-		Clientset:             cs,
-		HTTPClient:            c,
-		InClusterClient:       rc,
-		ClusterHostURL:        "https://" + ts.Listener.Addr().String(),
-		RetrieveNodeSummaries: true,
-		ConcurrentPollers:     10,
-		CollectionRetryLimit:  retries,
+		Clientset:            cs,
+		HTTPClient:           c,
+		InClusterClient:      rc,
+		ClusterHostURL:       "https://" + ts.Listener.Addr().String(),
+		ConcurrentPollers:    10,
+		CollectionRetryLimit: retries,
 	}
 	ka.NodeMetrics = EndpointMask{}
 	ka.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)

--- a/testdata/e2e/e2e_helper.go
+++ b/testdata/e2e/e2e_helper.go
@@ -1,22 +1,14 @@
 package test
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"math"
-	"path/filepath"
-	"strconv"
-	"strings"
-	"time"
-
-	"github.com/prometheus/common/expfmt"
-
 	cadvisor "github.com/google/cadvisor/info/v1"
 	"github.com/prometheus/prom2json"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+	"strings"
 )
 
 type ParsedK8sLists struct {
@@ -33,8 +25,6 @@ type ParsedK8sLists struct {
 	ReplicationControllers     LabelMapMatchedResourceList
 	NodeSummaries              map[string]statsapi.Summary
 	BaselineNodeSummaries      map[string]statsapi.Summary
-	NodeContainers             map[string]map[string]cadvisor.ContainerInfo
-	BaselineNodeContainers     map[string]map[string]cadvisor.ContainerInfo
 	CadvisorPrometheus         map[string]map[string]cadvisor.ContainerInfo
 	BaselineCadvisorPrometheus map[string]map[string]cadvisor.ContainerInfo
 	CldyAgent                  CldyAgent
@@ -160,8 +150,6 @@ var knownFileTypes = map[string]UnmarshalForK8sListFn{
 	"persistentvolumeclaims.json": ByRefFn(func(p *ParsedK8sLists) interface{} { return &p.PersistentVolumeClaims }),
 	"stats-summary-":              AsNodeSummary(false),
 	"baseline-summary-":           AsNodeSummary(true),
-	"stats-container-":            AsContainerNodeSummary(false),
-	"baseline-container-":         AsContainerNodeSummary(true),
 }
 
 var agentFileTypes = map[string]bool{
@@ -205,299 +193,6 @@ func AsNodeSummary(baseline bool) UnmarshalForK8sListFn {
 		summaries[s.Node.NodeName] = s
 		return nil
 	}
-}
-
-// AsContainerNodeSummary returns a UnmarshalForK8sListFn that will parse the data as a Container Summary
-func AsContainerNodeSummary(baseline bool) UnmarshalForK8sListFn {
-	return func(fname string, fdata []byte, parsedK8sList *ParsedK8sLists) error {
-		ci := map[string]cadvisor.ContainerInfo{}
-		err := json.Unmarshal(fdata, &ci)
-		if err != nil {
-			return err
-		}
-		nodeContainers := parsedK8sList.NodeContainers
-		if baseline {
-			nodeContainers = parsedK8sList.BaselineNodeContainers
-		}
-		nodeContainers[parseHostFromFileName(fname)] = ci
-		return nil
-	}
-}
-
-func parseHostFromFileName(fileName string) string {
-	s := strings.SplitAfterN(fileName, "-", 3)
-	return strings.TrimSuffix(s[2], filepath.Ext(s[2]))
-}
-
-func AsCadvisorMetrics(baseline bool) UnmarshalForK8sListFn {
-	return func(fname string, fdata []byte, parsedK8sList *ParsedK8sLists) error {
-		cPromMetrics, err := parseRawCadvisorPrometheusFile(fdata)
-		if err != nil {
-			return err
-		}
-		cPromMetricsCI := parsedK8sList.CadvisorPrometheus
-		if baseline {
-			cPromMetricsCI = parsedK8sList.BaselineCadvisorPrometheus
-		}
-		cPromMetricsCI[parseHostFromFileName(fname)] = cPromToContainerInfo(cPromMetrics)
-		return nil
-	}
-}
-
-func parseRawCadvisorPrometheusFile(fdata []byte) (map[string]*prom2json.Family, error) {
-	cPromMetrics := make(map[string]*prom2json.Family)
-	in := bytes.NewReader(fdata)
-	var parser expfmt.TextParser
-	metricFamilies, err := parser.TextToMetricFamilies(in)
-	if err != nil {
-		return nil, fmt.Errorf("reading cadvisor prometheus text format failed: %v", err)
-	}
-	for name, mf := range metricFamilies {
-		cPromMetrics[name] = prom2json.NewFamily(mf)
-	}
-	return cPromMetrics, nil
-}
-
-func cPromToContainerInfo(metricFamilies map[string]*prom2json.Family) map[string]cadvisor.ContainerInfo {
-	containerInfos := make(map[string]cadvisor.ContainerInfo)
-	missingMetrics := make(map[string]bool)
-	for metricName, metricsFamily := range metricFamilies {
-		for _, containerMetric := range metricsFamily.Metrics {
-			metric, ok := containerMetric.(prom2json.Metric)
-			if !ok {
-				continue
-			}
-			container := metric.Labels["id"]
-			if container == "" {
-				container = "node-level-metric"
-			}
-			var ci cadvisor.ContainerInfo
-			var err error
-			if ci, ok = containerInfos[container]; !ok {
-				ci, err = newContainerInfoFromCProm(metric, container)
-				if err != nil {
-					continue
-				}
-			}
-			ci = containerMetricsFromCProm(ci, metricName, metric, missingMetrics)
-			containerInfos[container] = ci
-		}
-	}
-	return containerInfos
-}
-
-func containerMetricsFromCProm(
-	ci cadvisor.ContainerInfo,
-	metricName string,
-	metric prom2json.Metric,
-	tmp map[string]bool) cadvisor.ContainerInfo {
-	converterFunc, ok := cPromToCIConversions[metricName]
-	if !ok {
-		tmp[metricName] = true
-		return ci
-	}
-	converterFunc(metric, &ci)
-	return ci
-}
-
-var cPromToCIConversions = map[string]metricConverter{
-	"container_fs_io_time_seconds_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		updateFileSystemEntry(metric, ci, func(fs cadvisor.FsStats) cadvisor.FsStats {
-			fs.IoTime = (strToUint(metric.Value) * 1000) // convert to milliseconds
-			return fs
-		})
-	},
-	// DiskIO
-	"container_fs_writes_bytes_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		updateDiskIOEntry(metric, ci, func(disk cadvisor.PerDiskStats) cadvisor.PerDiskStats {
-			metricVal := strToUint(metric.Value)
-			disk.Stats["Write"] = metricVal
-			disk.Stats["Total"] += metricVal
-			disk.Stats["Sync"] = metricVal
-			return disk
-		})
-	},
-	"container_fs_reads_bytes_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		updateDiskIOEntry(metric, ci, func(disk cadvisor.PerDiskStats) cadvisor.PerDiskStats {
-			bytesRead := strToUint(metric.Value)
-			disk.Stats["Read"] = bytesRead
-			disk.Stats["Total"] += bytesRead
-			return disk
-		})
-	},
-	// Filesystem
-	"container_fs_sector_reads_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		updateFileSystemEntry(metric, ci, func(fs cadvisor.FsStats) cadvisor.FsStats {
-			// Cumulative count of sector reads completed
-			fs.ReadsCompleted = strToUint(metric.Value)
-			return fs
-		})
-	},
-	"container_fs_limit_bytes": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		updateFileSystemEntry(metric, ci, func(fs cadvisor.FsStats) cadvisor.FsStats {
-			fs.Limit = strToUint(metric.Value)
-			return fs
-		})
-	},
-	"container_fs_usage_bytes": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		updateFileSystemEntry(metric, ci, func(fs cadvisor.FsStats) cadvisor.FsStats {
-			fs.Usage = strToUint(metric.Value)
-			var writeBytes uint64
-			updateDiskIOEntry(metric, ci, func(disk cadvisor.PerDiskStats) cadvisor.PerDiskStats {
-				writeBytes = disk.Stats["Write"]
-				return disk
-			})
-			if writeBytes >= fs.Usage {
-				fs.Available = writeBytes - fs.Usage
-			}
-			return fs
-		})
-	},
-	"container_start_time_seconds": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		tm := time.Unix(strToInt(metric.Value, 64), 0)
-		ci.Spec.CreationTime = tm.UTC()
-	},
-	"container_network_receive_errors_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		addNetworkEntries(metric, ci, func(net cadvisor.InterfaceStats) cadvisor.InterfaceStats {
-			net.RxErrors = strToUint(metric.Value)
-			return net
-		})
-	},
-	"container_spec_memory_limit_bytes": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Spec.Memory.Limit = strToUint(metric.Value)
-		ci.Spec.HasMemory = true
-	},
-	"container_memory_rss": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Memory.RSS = strToUint(metric.Value)
-	},
-	"container_memory_swap": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Memory.Swap = strToUint(metric.Value)
-
-	},
-	"container_cpu_cfs_periods_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Cpu.CFS.Periods = strToUint(metric.Value)
-	},
-	"container_cpu_load_average_10s": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Cpu.LoadAverage = int32(strToInt(metric.Value, 32))
-	},
-	"container_cpu_cfs_throttled_seconds_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Cpu.CFS.ThrottledTime = (strToUint(metric.Value) * 1e+9) // convert to nanoseconds
-	},
-	"container_cpu_usage_seconds_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Cpu.Usage.Total = strToUint(metric.Value)
-	},
-	"container_memory_failures_total": func(metric prom2json.Metric, ci *cadvisor.ContainerInfo) {
-		ci.Stats[0].Memory.Failcnt = strToUint(metric.Value)
-	},
-}
-
-func strToUint(str string) uint64 {
-	bitSize := 64
-	fl, err := strconv.ParseFloat(str, bitSize)
-	if err != nil {
-		return 0
-	}
-	rounded := math.Round(fl)
-	return uint64(rounded)
-}
-
-func strToInt(str string, bitSize int) int64 {
-	fl, err := strconv.ParseFloat(str, bitSize)
-	if err != nil {
-		return 0
-	}
-	rounded := math.Round(fl)
-	return int64(rounded)
-}
-
-func updateFileSystemEntry(m prom2json.Metric, ci *cadvisor.ContainerInfo, fn FileSystemMetricAdder) {
-	var fs cadvisor.FsStats
-	ci.Spec.HasFilesystem = true
-	for i, entry := range ci.Stats[0].Filesystem {
-		if entry.Device == m.Labels["device"] {
-			fs = fn(entry)
-			ci.Stats[0].Filesystem[i] = fs
-			return
-		}
-	}
-	fs.Device = m.Labels["device"]
-	fs = fn(fs)
-	ci.Stats[0].Filesystem = append(ci.Stats[0].Filesystem, fs)
-}
-
-func updateDiskIOEntry(m prom2json.Metric, ci *cadvisor.ContainerInfo, fn DiskIOMetricAdder) {
-	var fs cadvisor.PerDiskStats
-	ci.Spec.HasDiskIo = true
-	for i, entry := range ci.Stats[0].DiskIo.IoServiceBytes {
-		if entry.Device == m.Labels["device"] {
-			if entry.Stats == nil {
-				entry.Stats = make(map[string]uint64)
-			}
-			fs = fn(entry)
-			ci.Stats[0].DiskIo.IoServiceBytes[i] = fs
-			return
-		}
-	}
-	fs.Device = m.Labels["device"]
-	fs.Stats = make(map[string]uint64)
-	fs = fn(fs)
-	ci.Stats[0].DiskIo.IoServiceBytes = append(ci.Stats[0].DiskIo.IoServiceBytes, fs)
-}
-
-func addNetworkEntries(m prom2json.Metric, ci *cadvisor.ContainerInfo, fn NetworkMetricAdder) {
-	var net cadvisor.InterfaceStats
-	for i, entry := range ci.Stats[0].Network.Interfaces {
-		if entry.Name == m.Labels["interface"] {
-			net = fn(entry)
-			ci.Stats[0].Network.Interfaces[i] = net
-			return
-		}
-	}
-	net.Name = m.Labels["interface"]
-	net = fn(net)
-	ci.Stats[0].Network.Interfaces = append(ci.Stats[0].Network.Interfaces, net)
-}
-
-func newContainerInfoFromCProm(metric prom2json.Metric, container string) (cadvisor.ContainerInfo, error) {
-	if metric.TimestampMs == "" {
-		metric.TimestampMs = "0"
-	}
-	i, err := strconv.ParseInt(metric.TimestampMs, 10, 64)
-	if err != nil {
-		return cadvisor.ContainerInfo{}, fmt.Errorf("could not parse timestamp: %v", err)
-	}
-	tm := time.Unix(i, 0)
-	ci := cadvisor.ContainerInfo{
-		ContainerReference: cadvisor.ContainerReference{
-			Id:        metric.Labels["name"],
-			Name:      container,
-			Namespace: metric.Labels["namespace"],
-		},
-		Subcontainers: nil,
-		Spec: cadvisor.ContainerSpec{
-			Labels: map[string]string{
-				"io.kubernetes.container.name": metric.Labels["container"],
-				"io.kubernetes.pod.namespace":  metric.Labels["namespace"],
-				"io.kubernetes.pod.name":       metric.Labels["pod"],
-			},
-			Image: metric.Labels["image"],
-		},
-		Stats: []*cadvisor.ContainerStats{
-			{
-				Timestamp:     tm,
-				Cpu:           cadvisor.CpuStats{},
-				DiskIo:        cadvisor.DiskIoStats{},
-				Memory:        cadvisor.MemoryStats{},
-				Network:       cadvisor.NetworkStats{},
-				Filesystem:    nil,
-				TaskStats:     cadvisor.LoadStats{},
-				Accelerators:  nil,
-				Processes:     cadvisor.ProcessStats{},
-				CustomMetrics: nil,
-			},
-		},
-	}
-	return ci, nil
 }
 
 func toAgentFileType(n string) string {

--- a/testdata/e2e/e2e_helper.go
+++ b/testdata/e2e/e2e_helper.go
@@ -162,8 +162,6 @@ var knownFileTypes = map[string]UnmarshalForK8sListFn{
 	"baseline-summary-":           AsNodeSummary(true),
 	"stats-container-":            AsContainerNodeSummary(false),
 	"baseline-container-":         AsContainerNodeSummary(true),
-	"stats-cadvisor_metrics-":     AsCadvisorMetrics(false),
-	"baseline-cadvisor_metrics-":  AsCadvisorMetrics(true),
 }
 
 var agentFileTypes = map[string]bool{

--- a/testdata/e2e/e2e_test.go
+++ b/testdata/e2e/e2e_test.go
@@ -25,12 +25,10 @@ func TestMetricSample(t *testing.T) {
 	}
 
 	parsedK8sLists := &ParsedK8sLists{
-		NodeSummaries:              make(map[string]statsapi.Summary),
-		BaselineNodeSummaries:      make(map[string]statsapi.Summary),
-		NodeContainers:             make(map[string]map[string]cadvisor.ContainerInfo),
-		BaselineNodeContainers:     make(map[string]map[string]cadvisor.ContainerInfo),
-		CadvisorPrometheus:         make(map[string]map[string]cadvisor.ContainerInfo),
-		BaselineCadvisorPrometheus: make(map[string]map[string]cadvisor.ContainerInfo),
+		NodeSummaries:          make(map[string]statsapi.Summary),
+		BaselineNodeSummaries:  make(map[string]statsapi.Summary),
+		NodeContainers:         make(map[string]map[string]cadvisor.ContainerInfo),
+		BaselineNodeContainers: make(map[string]map[string]cadvisor.ContainerInfo),
 	}
 	t.Parallel()
 
@@ -117,27 +115,6 @@ func TestMetricSample(t *testing.T) {
 			t.Error("pod container stat data not found in metric sample")
 		}
 		return
-	})
-
-	t.Run("ensure that a metrics sample has expected cadvisor prometheus data", func(t *testing.T) {
-		for _, containerInfos := range parsedK8sLists.CadvisorPrometheus {
-			for _, containerInfo := range containerInfos {
-				if minorVersion >= 21 {
-					if strings.HasPrefix(containerInfo.Name, "/kubelet/kubepods/besteffort/pod") &&
-						containerInfo.Namespace == stress &&
-						strings.HasPrefix(containerInfo.Spec.Labels["io.kubernetes.pod.name"], stress) {
-						return
-					}
-				} else {
-					if strings.HasPrefix(containerInfo.Name, "/kubepods/besteffort/pod") &&
-						containerInfo.Namespace == stress &&
-						strings.HasPrefix(containerInfo.Spec.Labels["io.kubernetes.pod.name"], stress) {
-						return
-					}
-				}
-			}
-		}
-		t.Error("pod cadvisor prometheus data not found in metric sample")
 	})
 
 }

--- a/testdata/e2e/e2e_test.go
+++ b/testdata/e2e/e2e_test.go
@@ -99,22 +99,4 @@ func TestMetricSample(t *testing.T) {
 		}
 		t.Error("pod summary data not found in metric sample")
 	})
-
-	// 2020.9.10 - TODO: Remove this test once we stop supporting minor versions below 18
-	t.Run("ensure that a metrics sample has expected containers stat data", func(t *testing.T) {
-		if minorVersion < 18 {
-			for _, nc := range parsedK8sLists.NodeContainers {
-
-				for _, s := range nc {
-					if strings.HasPrefix(s.Name, "/kubepods/besteffort/pod") && s.Namespace == "containerd" && strings.HasPrefix(
-						s.Spec.Labels["io.kubernetes.pod.name"], stress) {
-						return
-					}
-				}
-			}
-			t.Error("pod container stat data not found in metric sample")
-		}
-		return
-	})
-
 }

--- a/testdata/e2e/e2e_test.go
+++ b/testdata/e2e/e2e_test.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"testing"
 
-	cadvisor "github.com/google/cadvisor/info/v1"
 	v1 "k8s.io/api/core/v1"
 	statsapi "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
@@ -25,10 +24,8 @@ func TestMetricSample(t *testing.T) {
 	}
 
 	parsedK8sLists := &ParsedK8sLists{
-		NodeSummaries:          make(map[string]statsapi.Summary),
-		BaselineNodeSummaries:  make(map[string]statsapi.Summary),
-		NodeContainers:         make(map[string]map[string]cadvisor.ContainerInfo),
-		BaselineNodeContainers: make(map[string]map[string]cadvisor.ContainerInfo),
+		NodeSummaries:         make(map[string]statsapi.Summary),
+		BaselineNodeSummaries: make(map[string]statsapi.Summary),
 	}
 	t.Parallel()
 
@@ -58,7 +55,6 @@ func TestMetricSample(t *testing.T) {
 
 				}
 			}
-
 			return nil
 		})
 		if err != nil {
@@ -84,7 +80,6 @@ func TestMetricSample(t *testing.T) {
 			if strings.HasPrefix(po.Name, stress) && po.Status.QOSClass == v1.PodQOSBestEffort {
 				return
 			}
-
 		}
 		t.Error("pod stress not found in metric sample")
 	})

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "2.10.1"
+var VERSION = "2.11.0"


### PR DESCRIPTION
#### What does this PR do?
Removes Prometheus data from metric agent uploads. This is currently in progress to be removed from the Cloudability pipeline, and should cut down metric file uploads significantly on large clusters.

#### Where should the reviewer start?

#### How should this be manually tested?
Stick it on a cluster, let it run.

#### Any background context you want to provide?
The prometheus data can be quite large and processing intensive. This will remove it's collection.

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)