### PR TITLE
Enhance agent startup logging, more generous startup restrictions

### DIFF
--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.11.0
+version: 2.11.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.11.0
+appVersion: 2.11.1

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -19,7 +19,7 @@ pollInterval: 180
 
 image:
   name: cloudability/metrics-agent
-  tag: 2.11.0
+  tag: 2.11.1
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -415,7 +415,19 @@ func ensureNodeSource(ctx context.Context, config KubeAgentConfig) (KubeAgentCon
 		return config, FatalNodeError
 	}
 
+	validateConfig(config, proxyNodes, directNodes)
 	return config, nil
+}
+
+func validateConfig(config KubeAgentConfig, proxyNodes, directNodes int32) {
+	if proxyNodes > 0 {
+		config.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Proxy, true)
+	} else if directNodes > 0 {
+		config.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, true)
+	} else {
+		config.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Proxy, false)
+		config.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, Direct, false)
+	}
 }
 
 func checkEndpointConnections(config KubeAgentConfig, client *http.Client, method Connection,
@@ -425,7 +437,6 @@ func checkEndpointConnections(config KubeAgentConfig, client *http.Client, metho
 		return false, err
 	}
 	log.Infof("Node [%s] available via %s connection? %v", nodeStatSum, method, ns)
-	config.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, method, ns)
 
 	return ns, nil
 }

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -409,7 +409,7 @@ func checkEndpointConnections(config KubeAgentConfig, client *http.Client, metho
 	if err != nil {
 		return false, err
 	}
-	log.Infof("/stats/summary endpoint on node [%s] available via %s connection? %v", nodeStatSum, method, ns)
+	log.Infof("Node [%s] available via %s connection? %v", nodeStatSum, method, ns)
 	config.NodeMetrics.SetAvailability(NodeStatsSummaryEndpoint, method, ns)
 
 	return ns, nil

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -396,7 +396,7 @@ func ensureNodeSource(ctx context.Context, config KubeAgentConfig) (KubeAgentCon
 			"agent will operate in a limited mode.", pct)
 	}
 
-	if (len(nodes) - failedProxy) == 0 {
+	if (directNodes + proxyNodes) == 0 {
 		return config, FatalNodeError
 	}
 

--- a/kubernetes/nodecollection.go
+++ b/kubernetes/nodecollection.go
@@ -346,8 +346,6 @@ func ensureNodeSource(ctx context.Context, config KubeAgentConfig) (KubeAgentCon
 		return config, fmt.Errorf("error retrieving nodes: %s", err)
 	}
 
-	firstNode := &nodes[0]
-
 	directNodes := 0
 	proxyNodes := 0
 	failedDirect := 0
@@ -374,7 +372,7 @@ func ensureNodeSource(ctx context.Context, config KubeAgentConfig) (KubeAgentCon
 			}
 		}
 		if !directlyConnected {
-			p := setupProxyAPI(config.ClusterHostURL, firstNode.Name)
+			p := setupProxyAPI(config.ClusterHostURL, nodes[i].Name)
 			success, err := checkEndpointConnections(config, &config.HTTPClient, Proxy, p.statsSummary())
 			if err != nil {
 				log.Warnf("Failed to connect to node [%s] via proxy with cause [%s]",

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 //VERSION is the current version of the agent
-var VERSION = "2.11.0"
+var VERSION = "2.11.1"


### PR DESCRIPTION
#### What does this PR do?
Previously the agent would fail to start up in the case that the first "ready" node was unavailable or encountered an issue. 
This pr adds logging for all nodes on startup and changes the requirement to only fail if none are available.

#### Where should the reviewer start?

#### How should this be manually tested?
Stick it in a cluster

#### Any background context you want to provide?
Customer request to have more details information on reason for failure on startup as well as a more generous policy on per-node requirements.

#### What picture best describes this PR (optional but encouraged)?
![Screen Shot 2022-09-16 at 10 34 26 AM](https://user-images.githubusercontent.com/43144225/190665061-561b2fef-f9cc-4415-ae36-047fda63f8e9.png)

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)