### PR TITLE
Add HPA and PDB

### DIFF
--- a/charts/metrics-agent/templates/hpa.yaml
+++ b/charts/metrics-agent/templates/hpa.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "metrics-agent.fullname" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "metrics-agent.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  targetCPUUtilizationPercentage: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/metrics-agent/templates/pdb.yaml
+++ b/charts/metrics-agent/templates/pdb.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "metrics-agent.fullname" . }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  selector:
+    matchLabels:
+      app: {{ include "metrics-agent.fullname" . }}
+{{- end }}

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -28,6 +28,16 @@ image:
   pullPolicy: Always
 
 imagePullSecrets: []
+# HorizontalPodAutoscaler 
+hpa:
+  enabled: false
+  minReplicas: 1 
+  maxReplicas: 3
+  targetCPUUtilizationPercentage: 80
+#Disruption Budget for the Application in caes of node upgrades
+pdb: 
+  enabled: false
+  minAvailable: 1 
 
 resources:
   requests:


### PR DESCRIPTION
#### What does this PR do?
Adding HorizontalPodAutoscaler and Disruption Budget for the Application
#### Where should the reviewer start?
https://github.com/cloudability/metrics-agent/tree/master/charts/metrics-agent 
 added : 
      - pdb.yaml
      - hpa.yaml
 update:
      - values.yaml with pdb and hap. By default both are disabled with false value so no change and can be enabled with true value
#### How should this be manually tested?
Command to see the resources 
 ```bash
  helm template cloudability  . -f values.yaml --dry-run | more
 ```
#### Any background context you want to provide?
We are creating our own helm chart but would like to use the public one so adding all our new features to public helm charts for everyones benefits. 
#### What picture best describes this PR (optional but encouraged)?
 Adding HorizontalPodAutoscaler and Disruption Budget for the Application
#### What are the relevant Github Issues?
 No issue
#### Developer Done List

- [ YES] Tests Added/Updated
- [ NO] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ YES] Considered Security, Availability and Confidentiality

#### For the Reviewer:
Just HPA and PDB's are added so no functionality change. Everything else will be same. 
#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)