### PR TITLE
Allow templating of additional labels on resources

### DIFF
--- a/charts/metrics-agent/templates/_helpers.tpl
+++ b/charts/metrics-agent/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "metrics-agent.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.additionalLabels }}
+{{ toYaml .Values.additionalLabels }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -12,7 +12,10 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "metrics-agent.selectorLabels" . | nindent 8 }}
+        {{- include "metrics-agent.labels" . | nindent 8 }}
+        {{- if .Values.additionalPodLabels }}
+        {{ toYaml .Values.additionalPodLabels }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -37,6 +37,12 @@ resources:
     cpu: "1.0"
     memory: "4Gi"
 
+# Extra labels to add to the pod only.
+additionalPodLabels: {}
+
+# Extra labels to add to all resources, including pods.
+additionalLabels: {}
+
 livenessProbe:
   exec:
     command:
@@ -73,5 +79,5 @@ openShift: false
 seccompProfile:
   type: RuntimeDefault
 
-drop: 
+drop:
 - ALL


### PR DESCRIPTION
#### What does this PR do?

This commit introduces two optional values in the Helm chart - `additionalPodLabels` and `additionalLabels`. The former will apply the supplied labels on to the templated pod only, whereas the latter will apply them to all resources - including the pod.

These labels are applied in addition to the existing labels that the chart supplies. This therefore allows users to supply their own additional labels without affecting the essential labels supplied by the chart.

This is useful for situations where a user needs to supply additional labels for audit/attribution purposes... including attributing cost within Cloudability itself!

The deployment template was changed to include all labels on the pod, rather than just the selectorLabels. This does not impact the Deployment's selector, as it only looks for a subset of labels - not complete equality. As a result, even if a user does not supply any additional labels, this change will result in their pod gaining the `app.kubernetes.io/version` and `app.kubernetes.io/managed-by` labels that are already present on all other resources.

I have **not** bumped the chart version in `Chart.yaml`, as I am unsure of what the release process is for this chart.

#### How should this be manually tested?

Template the chart using the default set of values (i.e. no additional labels), and then supply values for `additionalPodLabels` and `additionalLabels`. Observe that these are now included in the 

#### Any background context you want to provide?

We attribute cost within Cloudability based on specific internal-use labels on pods - this allows for a finer-grained breakdown than namespace-labelling alone. However, this means that we need to be able to put this label on all pods, which we are currently unable to do with the existing chart. Hence, the Cloudability Metrics Agent is currently an unattributed cost within Cloudability itself.

We also use these internal-use labels also help to attribute general ownership of resources - hence we wish to put them on all resources, not just pods. It is common in many Helm charts to allow users to add additional labels to all resources, as well as add pod labels only.

#### What are the relevant Github Issues?

N/A

#### Developer Done List

- [ ] Tests Added/Updated
_N/A - there are no chart tests_
- [ ] Updated README.md
_N/A - the README does not detail Helm values_
- [x] Verified backward compatible
_For existing users, this will only result in their pod gaining the `app.kubernetes.io/version` and `app.kubernetes.io/managed-by` labels that are already present on all other resources. Supplying additional labels is optional._
- [ ] Verified database migrations will not be catastrophic
_N/A - This is only a change to the chart, not the agent itself and hence migrations do not come in to play._
- [x] Considered Security, Availability and Confidentiality
_This change does not change any security properties of the agent or the Kubernetes resources_

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)