### PR TITLE
adding pod annotions and readonlyrootfilesystem capabilities

### DIFF
--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         {{- include "metrics-agent.labels" . | nindent 8 }}
         {{- if .Values.podLabels }}{{ toYaml .Values.podLabels | nindent 8 }}{{- end }}
+    {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -33,6 +37,7 @@ spec:
             capabilities:
               drop:
                 {{ .Values.drop }}
+            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - 'kubernetes'

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -90,5 +90,10 @@ podLabels: {}
 # Extra labels to add to all resources, including pods.
 additionalLabels: {}
 
+# Extra annotations to add to the pod only.
+podAnnotations: {}
+
+readOnlyRootFilesystem: false
+
 drop: 
 - ALL


### PR DESCRIPTION
#### What does this PR do?
Add podAnnotations and containers. securityContext.readOnlyRootFilesystem capabilities,
so that they can be added or modified for metrics-agent's deployment manifest

#### Where should the reviewer start?
deployment.yaml

#### How should this be manually tested?
For annotation, in values file, add new podAnnotations and check if it's added in a metrics-agent pod.
For readOnlyRootFilesystem, change readOnlyRootFilesystem value to true and check if it's changed in a metrics-agent pod.

#### Any background context you want to provide?
Our organization highly values security vulnerability and tracking, and these capabilities are needed to comply with that.

#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [x] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)