### PR TITLE
Allow Annotations in Helm chart

### DIFF
--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.11.26
+version: 2.11.27
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.11.26
+appVersion: 2.11.27

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -14,10 +14,8 @@ spec:
       labels:
         {{- include "metrics-agent.labels" . | nindent 8 }}
         {{- if .Values.podLabels }}{{ toYaml .Values.podLabels | nindent 8 }}{{- end }}
-    { { - with .Values.podAnnotations } }
-    annotations:
-      { { - toYaml . | nindent 8 } }
-    { { - end } }
+      annotations:
+        {{- if .Values.podAnnotations }}{{ toYaml .Values.podAnnotations | nindent 8 }}{{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         {{- include "metrics-agent.labels" . | nindent 8 }}
         {{- if .Values.podLabels }}{{ toYaml .Values.podLabels | nindent 8 }}{{- end }}
+    { { - with .Values.podAnnotations } }
+    annotations:
+      { { - toYaml . | nindent 8 } }
+    { { - end } }
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -33,6 +37,7 @@ spec:
             capabilities:
               drop:
                 {{ .Values.drop }}
+            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - 'kubernetes'

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -35,7 +35,6 @@ spec:
             capabilities:
               drop:
                 {{ .Values.drop }}
-            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - 'kubernetes'

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -35,6 +35,7 @@ spec:
             capabilities:
               drop:
                 {{ .Values.drop }}
+            readOnlyRootFilesystem: {{ .Values.readOnlyRootFilesystem }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - 'kubernetes'

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -24,7 +24,7 @@ pollInterval: 180
 
 image:
   name: cloudability/metrics-agent
-  tag: 2.11.26
+  tag: 2.11.27
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -89,6 +89,11 @@ podLabels: {}
 
 # Extra labels to add to all resources, including pods.
 additionalLabels: {}
+
+# Extra annotations to add to the pod only.
+podAnnotations: {}
+
+readOnlyRootFilesystem: false
 
 drop: 
 - ALL

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -93,7 +93,17 @@ additionalLabels: {}
 # Extra annotations to add to the pod only.
 podAnnotations: {}
 
-# when toggling to true, the proper volumeMount must be configured correctly otherwise the agent will crash
+# when setting readOnlyRootFilesystem to true, the proper volume/volumeMount must be
+# configured correctly otherwise the agent will crash
+# the following volumes: and volumeMounts: sections below
+# will allow the agent to run successfully with readOnlyRootFilesystem set to true
+#volumeMounts:
+#  - mountPath: /tmp
+#    name: tmp
+#
+#volumes:
+#  - emptyDir: {}
+#    name: tmp
 readOnlyRootFilesystem: false
 
 drop: 

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -93,7 +93,5 @@ additionalLabels: {}
 # Extra annotations to add to the pod only.
 podAnnotations: {}
 
-readOnlyRootFilesystem: false
-
 drop: 
 - ALL

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -93,5 +93,8 @@ additionalLabels: {}
 # Extra annotations to add to the pod only.
 podAnnotations: {}
 
+# when toggling to true, the proper volumeMount must be configured correctly otherwise the agent will crash
+readOnlyRootFilesystem: false
+
 drop: 
 - ALL

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION is the current version of the agent
-var VERSION = "2.11.26"
+var VERSION = "2.11.27"


### PR DESCRIPTION
#### What does this PR do?
Adds optional annotations to the helm chart deployment
#### Where should the reviewer start?
helm chart configs
#### How should this be manually tested?
Deployed on a test cluster where Values.yaml podAnnotations was empty. 
Also deployed where podAnnotations contained an annotation
#### Any background context you want to provide?
Shout out to @Gyuncho for the pull request! https://github.com/cloudability/metrics-agent/pull/260
#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [x] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)