### PR TITLE
feat(266): Add extraObjects to Helm Chart.

### DIFF
--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.11.29
+version: 2.11.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.11.29
+appVersion: 2.11.30

--- a/charts/metrics-agent/templates/extra-manifests.yaml
+++ b/charts/metrics-agent/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -108,3 +108,18 @@ readOnlyRootFilesystem: false
 
 drop: 
 - ALL
+
+# Extra K8s manifests to deploy
+extraObjects: []
+# - apiVersion: external-secrets.io/v1beta1
+#   kind: SecretStore
+#   metadata:
+#     name: aws-store-cloudability
+#     annotations:     
+#       argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true  
+#       argocd.argoproj.io/sync-wave: "99"
+#   spec:
+#     provider:
+#       aws:
+#         service: SecretsManager
+#         region: us-west-2


### PR DESCRIPTION
#### What does this PR do?
Allows the creation of additional resources from the helm chart such as `SecretStore`/`ExternalSecret` resources. This is a common approach followed by many open-source charts
Solves:
https://github.com/cloudability/metrics-agent/issues/266

#### Where should the reviewer start?
Helm Chart

#### How should this be manually tested?
Comment out the sample resource in `values.yaml` and run `helm template .`

#### Any background context you want to provide?

#### What picture best describes this PR (optional but encouraged)?
N/A
#### What are the relevant Github Issues?
https://github.com/cloudability/metrics-agent/issues/266

#### Developer Done List

- [X] Tests Added/Updated
- [X] Updated README.md - No changes to readme
- [X] Verified backward compatible - Default value in place in values.yaml with a empty array
- [X] Verified database migrations will not be catastrophic - Not Applicable
- [X] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)