### PR TITLE
Add extraObjects to Helm Chart & Re-Install Curl

### DIFF
--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.11.29
+version: 2.11.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.11.29
+appVersion: 2.11.30

--- a/charts/metrics-agent/templates/extra-objects.yaml
+++ b/charts/metrics-agent/templates/extra-objects.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -24,7 +24,7 @@ pollInterval: 180
 
 image:
   name: cloudability/metrics-agent
-  tag: 2.11.29
+  tag: 2.11.30
   pullPolicy: Always
 
 imagePullSecrets: []
@@ -108,3 +108,21 @@ readOnlyRootFilesystem: false
 
 drop: 
 - ALL
+
+# Extra K8s manifests to deploy,
+# NOTE: not all various extraObject deployment configurations are tested/supported. When adding extra resources
+# to the metrics-agent deployment, Cloudability may not be able to assist in deployment troubleshooting
+extraObjects: []
+# Example extra manifest
+# - apiVersion: external-secrets.io/v1beta1
+#   kind: SecretStore
+#   metadata:
+#     name: aws-store-xxxxx
+#     annotations:
+#       argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+#       argocd.argoproj.io/sync-wave: "99"
+#   spec:
+#     provider:
+#       aws:
+#         service: SecretsManager
+#         region: us-west-2

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION is the current version of the agent
-var VERSION = "2.11.29"
+var VERSION = "2.11.30"


### PR DESCRIPTION
#### What does this PR do?
Adds the optional cofiguration to support extraObjects in the Helm chart deployment of the metrics-agent. 
This allows customers who deploy custom external objects to include them in their chart manifest (for example an aws secretStore to manage the CLOUDABILITY_API_KEY).

It is called out in the chart that not all extraObject deployment configurations are explicitly supported/tested and Cloudability may not be able to help troubleshoot all cases.

The version of curl installed on the 2.11.29 metrics-agent is also vulnerable, releasing this version will install the newer (non-vulnerable) version.
#### Where should the reviewer start?
Helm Chart
#### How should this be manually tested?
Deployed to a test cluster without any extraObjects configured and ensured no regressions
Deployed extra test resource in extraObjects to ensure it is working correctly
#### Any background context you want to provide?
Nope
#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [x] Tests Added/Updated
- [x] Updated README.md
- [x] Verified backward compatible
- [x] Verified database migrations will not be catastrophic
- [x] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)