### PR TITLE
Allow API Key to be Mounted As Volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,26 +36,27 @@ Cloudability Metrics Agent currently does not support Rancher or On Prem cluster
 
 ### Configuration Options
 
-| Environment Variable                           |                                                                                             Description                                                                                              |
-|------------------------------------------------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
-| CLOUDABILITY_API_KEY                           |                                                                                    Required: Cloudability api key                                                                                    |
-| CLOUDABILITY_CLUSTER_NAME                      |                                                            Required: The cluster name to be used for the cluster the agent is running in. Cannot be exclusively whitespace.                            |
-| CLOUDABILITY_POLL_INTERVAL                     |                                                                    Optional: The interval (Seconds) to poll metrics. Default: 180                                                                    |
-| CLOUDABILITY_OUTBOUND_PROXY                    |                    Optional: The URL of an outbound HTTP/HTTPS proxy for the agent to use (eg: http://x.x.x.x:8080). The URL must contain the scheme prefix (http:// or https://)                    |
-| CLOUDABILITY_OUTBOUND_PROXY_AUTH               | Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password |
-| CLOUDABILITY_OUTBOUND_PROXY_INSECURE           |                                                 Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False                                                  |
-| CLOUDABILITY_INSECURE                          |                                                    Optional: When true, does not verify certificates when making TLS connections. Default: False                                                     |
-| CLOUDABILITY_FORCE_KUBE_PROXY                  |                                  Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False                                   |
-| CLOUDABILITY_COLLECTION_RETRY_LIMIT            |                                             Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1                                              |
-| CLOUDABILITY_NAMESPACE                         |        Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`         |
-| CLOUDABILITY_LOG_FORMAT                        |                                                                     Optional: Format for log output (JSON,PLAIN) Default: PLAIN                                                                      |
-| CLOUDABILITY_LOG_LEVEL                         |                                                           Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`                                                           |
-| CLOUDABILITY_SCRATCH_DIR                       | Optional: Temporary directory that metrics will be written to. If set, must assure that the directory exists and that the user agent UID 10000 has read/write access to the folder. Default: `/tmp`  |
-| CLOUDABILITY_NUMBER_OF_CONCURRENT_NODE_POLLERS |                                                   Optional: Number of goroutines that are created to poll node metrics in parallel. Default: `100`                                                   |
-| CLOUDABILITY_INFORMER_RESYNC_INTERVAL          |                      Optional: Period of time (in hours) that the informers will fully resync the list of running resources. Default: 24 hours. Can be set to 0 to never resync                      |
-| CLOUDABILITY_PARSE_METRIC_DATA                 |                                        Optional: When true, core files will be parsed and non-relevant data will be removed prior to upload. Default: `false`                                        |
-| CLOUDABILITY_HTTPS_CLIENT_TIMEOUT              |                   Optional: Amount (in seconds) of time the http client has before timing out requests. Might need to be increased to clusters with large payloads. Default: `60`                    |
-| CLOUDABILITY_UPLOAD_REGION                     |          Optional: The region the metrics-agent will upload data to. Default `us-west-2`. Supported values: `us-west-2`, `eu-central-1`, `ap-southeast-2`, `me-central-1`, `us-gov-west-1`           |
+| Environment Variable                           |                                                                                                              Description                                                                                                              |
+|------------------------------------------------|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
+| CLOUDABILITY_API_KEY                           |                                                           Cloudability api key. Not recommended to store as environment variable, instead use CLOUDABILITY_API_KEY_FILEPATH                                                           |
+| CLOUDABILITY_API_KEY_FILEPATH                  |                                                                          Path to the file where the api key is stored, ex: /etc/secrets/CLOUDABILITY_API_KEY                                                                          |
+| CLOUDABILITY_CLUSTER_NAME                      |                                                           Required: The cluster name to be used for the cluster the agent is running in. Cannot be exclusively whitespace.                                                            |
+| CLOUDABILITY_POLL_INTERVAL                     |                                                                                    Optional: The interval (Seconds) to poll metrics. Default: 180                                                                                     |
+| CLOUDABILITY_OUTBOUND_PROXY                    |                                    Optional: The URL of an outbound HTTP/HTTPS proxy for the agent to use (eg: http://x.x.x.x:8080). The URL must contain the scheme prefix (http:// or https://)                                     |
+| CLOUDABILITY_OUTBOUND_PROXY_AUTH               |                 Optional: Basic Authentication credentials to be used with the defined outbound proxy. If your outbound proxy requires basic authentication credentials can be defined in the form username:password                  |
+| CLOUDABILITY_OUTBOUND_PROXY_INSECURE           |                                                                  Optional: When true, does not verify TLS certificates when using the outbound proxy. Default: False                                                                  |
+| CLOUDABILITY_INSECURE                          |                                                                     Optional: When true, does not verify certificates when making TLS connections. Default: False                                                                     |
+| CLOUDABILITY_FORCE_KUBE_PROXY                  |                                                   Optional: When true, forces agent to use the proxy to connect to nodes rather than attempting a direct connection. Default: False                                                   |
+| CLOUDABILITY_COLLECTION_RETRY_LIMIT            |                                                              Optional: Number of times agent should attempt to gather metrics from each source upon a failure Default: 1                                                              |
+| CLOUDABILITY_NAMESPACE                         |                         Optional: Override the namespace that the agent runs in. It is not recommended to change this as it may negatively affect the agents ability to collect data. Default: `cloudability`                         |
+| CLOUDABILITY_LOG_FORMAT                        |                                                                                      Optional: Format for log output (JSON,PLAIN) Default: PLAIN                                                                                      |
+| CLOUDABILITY_LOG_LEVEL                         |                                                                           Optional: Log level to run the agent at (INFO,WARN,DEBUG,TRACE). Default: `INFO`                                                                            |
+| CLOUDABILITY_SCRATCH_DIR                       |                  Optional: Temporary directory that metrics will be written to. If set, must assure that the directory exists and that the user agent UID 10000 has read/write access to the folder. Default: `/tmp`                  |
+| CLOUDABILITY_NUMBER_OF_CONCURRENT_NODE_POLLERS |                                                                   Optional: Number of goroutines that are created to poll node metrics in parallel. Default: `100`                                                                    |
+| CLOUDABILITY_INFORMER_RESYNC_INTERVAL          |                                      Optional: Period of time (in hours) that the informers will fully resync the list of running resources. Default: 24 hours. Can be set to 0 to never resync                                       |
+| CLOUDABILITY_PARSE_METRIC_DATA                 |                                                        Optional: When true, core files will be parsed and non-relevant data will be removed prior to upload. Default: `false`                                                         |
+| CLOUDABILITY_HTTPS_CLIENT_TIMEOUT              |                                    Optional: Amount (in seconds) of time the http client has before timing out requests. Might need to be increased to clusters with large payloads. Default: `60`                                    |
+| CLOUDABILITY_UPLOAD_REGION                     |                           Optional: The region the metrics-agent will upload data to. Default `us-west-2`. Supported values: `us-west-2`, `eu-central-1`, `ap-southeast-2`, `me-central-1`, `us-gov-west-1`                           |
 
 ```sh
 
@@ -66,7 +67,8 @@ Usage:
   metrics-agent kubernetes [flags]
 
 Flags:
-      --api_key string                           Cloudability API Key - required
+      --api_key string                           Cloudability api key. Not recommended to store as environment variable, instead use CLOUDABILITY_API_KEY_FILEPATH
+      --api_key_filepath                         Path to the file where the api key is stored, ex: /etc/secrets/CLOUDABILITY_API_KEY 
       --certificate_file string                  The path to a certificate file. - Optional
       --cluster_name string                      Kubernetes Cluster Name - required this must be unique to every cluster.
       --collection_retry_limit uint              Number of times agent should attempt to gather metrics from each source upon a failure (default 1)
@@ -98,7 +100,9 @@ There are two ways to deploy Metrics-agent:
 
 Cloudability customers can download the deployment yaml directly from Cloudability UI. The downloaded yaml contains default settings including the API key needed to enable the metrics-agent to upload metrics to Cloudability. The customer should change the default settings in the yaml according to their clusters' configuration and security requirements.
 
-The API key is currently configured as an environment variable in the pod as plain text. It's highly recommended to integrate the API key with the customer's own secret manager solution. This could be the CSP's secret manager such as AWS secret manager, GCP secret manager, etc. Please refer to Kubernetes and CSP document for such integration.
+The API key is currently supported as an environment variable in the pod as plain text. However, it is highly recommended to update the agent version to >2.13.0 and to pull from a mounted volume using CLOUDABILITY_API_KEY_FILEPATH. Customers can also use various CSP's secret manager such as AWS secret manager, GCP secret manager, etc to then mount on the agent. Please refer to Kubernetes and CSP document for such integration.
+
+Note: If the metrics-agent was deployed using the older template, ensure you provision the new YAML from either Helm >2.13.0 or the UI that creates a Kubernetes secret and mounts the correct volume before updating to use CLOUDABILITY_API_KEY_FILEPATH.
 
 ### Deployment using helm
 

--- a/charts/metrics-agent/Chart.yaml
+++ b/charts/metrics-agent/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.12.1
+version: 2.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 2.12.1
+appVersion: 2.13.0

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -40,17 +40,14 @@ spec:
           args:
           - 'kubernetes'
           env:
-            - name: "CLOUDABILITY_API_KEY"
-              valueFrom:
-                secretKeyRef:
-                  name: {{- if not .Values.secretName }} {{ include "metrics-agent.fullname" . }} {{- else }} {{ .Values.secretName }} {{- end }}
-                  key: CLOUDABILITY_API_KEY
             - name: CLOUDABILITY_CLUSTER_NAME
               value: {{ .Values.clusterName }}
             - name: CLOUDABILITY_POLL_INTERVAL
               value: {{ .Values.pollInterval | quote }}
             - name: CLOUDABILITY_UPLOAD_REGION
               value: {{ .Values.uploadRegion }}
+            - name: CLOUDABILITY_API_KEY_FILEPATH
+              value: {{ .Values.fullPathToApiKey }}
             {{- if .Values.extraEnv }}
               {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
@@ -58,14 +55,20 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
-          {{- with .Values.volumeMounts }}
           volumeMounts:
-          {{- toYaml . | nindent 12 }}
-          {{- end }}
-      {{- with .Values.volumes }}
+            - name: api-key-volume
+              mountPath: {{ .Values.volumePathForApiKey }}
+              readOnly: true
+            {{- if .Values.volumeMounts }}
+              {{- toYaml .Values.volumeMounts | nindent 12 }}
+            {{- end }}
       volumes:
-      {{- toYaml . | nindent 8 }}
-      {{- end }}
+        - name: api-key-volume
+          secret:
+            secretName: {{ include "metrics-agent.fullname" . }}
+        {{- if .Values.volumes }}
+          {{- toYaml .Values.volumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/metrics-agent/templates/deployment.yaml
+++ b/charts/metrics-agent/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
             - name: CLOUDABILITY_UPLOAD_REGION
               value: {{ .Values.uploadRegion }}
             - name: CLOUDABILITY_API_KEY_FILEPATH
-              value: {{ .Values.fullPathToApiKey }}
+              value: {{ .Values.pathToApiKey -}}/{{ .Values.fileNameWithApiKey }}
             {{- if .Values.extraEnv }}
               {{- toYaml .Values.extraEnv | nindent 12 }}
             {{- end }}
@@ -57,7 +57,7 @@ spec:
             {{- toYaml .Values.livenessProbe | nindent 12 }}
           volumeMounts:
             - name: api-key-volume
-              mountPath: {{ .Values.volumePathForApiKey }}
+              mountPath: {{ .Values.pathToApiKey }}
               readOnly: true
             {{- if .Values.volumeMounts }}
               {{- toYaml .Values.volumeMounts | nindent 12 }}

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -11,10 +11,10 @@ fullnameOverride: ""
 # In the Cloudability app, go to Insights -> Containers, then click
 # the provisioning cluster button that will take you through our provisioning workflow.
 apiKey: ""
-# configurable full path to the location where the CLOUDABILITY_API_KEY is stored on the container
-fullPathToApiKey: "/etc/secrets/CLOUDABILITY_API_KEY"
-# configurable path to the directory the api key is stored
-volumePathForApiKey: "/etc/secrets"
+# configurable path to the location where the CLOUDABILITY_API_KEY is stored on the container
+pathToApiKey: "/etc/secrets"
+# configurable fileName to the file where the api key is stored
+fileNameWithApiKey: "CLOUDABILITY_API_KEY"
 
 # You may also store the apikey in a secret and pull the apikey from there as well.
 # name of the secret already stored in k8s containing CLOUDABILITY_API_KEY.

--- a/charts/metrics-agent/values.yaml
+++ b/charts/metrics-agent/values.yaml
@@ -11,6 +11,10 @@ fullnameOverride: ""
 # In the Cloudability app, go to Insights -> Containers, then click
 # the provisioning cluster button that will take you through our provisioning workflow.
 apiKey: ""
+# configurable full path to the location where the CLOUDABILITY_API_KEY is stored on the container
+fullPathToApiKey: "/etc/secrets/CLOUDABILITY_API_KEY"
+# configurable path to the directory the api key is stored
+volumePathForApiKey: "/etc/secrets"
 
 # You may also store the apikey in a secret and pull the apikey from there as well.
 # name of the secret already stored in k8s containing CLOUDABILITY_API_KEY.
@@ -26,7 +30,7 @@ uploadRegion: "us-west-2"
 
 image:
   name: cloudability/metrics-agent
-  tag: 2.12.1
+  tag: 2.13.0
   pullPolicy: Always
 
 imagePullSecrets: []

--- a/cmd/kubernetesCmd.go
+++ b/cmd/kubernetesCmd.go
@@ -34,7 +34,7 @@ func init() {
 		&config.APIKey,
 		"api_key",
 		"",
-		"Cloudability API Key - required",
+		"Cloudability API Key - required if api key is not stored in volume mount",
 	)
 	kubernetesCmd.PersistentFlags().StringVar(
 		&config.ClusterName,
@@ -151,6 +151,12 @@ func init() {
 		"",
 		"The AWS region that the custom s3 bucket is in",
 	)
+	kubernetesCmd.PersistentFlags().StringVar(
+		&config.APIKeyFilepath,
+		"api_key_filepath",
+		"",
+		"Recommended - The file path where the api key is stored",
+	)
 
 	//nolint gas
 	_ = viper.BindPFlag("api_key", kubernetesCmd.PersistentFlags().Lookup("api_key"))
@@ -178,6 +184,7 @@ func init() {
 	_ = viper.BindPFlag("upload_region", kubernetesCmd.PersistentFlags().Lookup("upload_region"))
 	_ = viper.BindPFlag("custom_s3_bucket", kubernetesCmd.PersistentFlags().Lookup("custom_s3_bucket"))
 	_ = viper.BindPFlag("custom_s3_region", kubernetesCmd.PersistentFlags().Lookup("custom_s3_region"))
+	_ = viper.BindPFlag("api_key_filepath", kubernetesCmd.PersistentFlags().Lookup("api_key_filepath"))
 	viper.SetEnvPrefix("cloudability")
 	viper.AutomaticEnv()
 
@@ -204,6 +211,7 @@ func init() {
 		UploadRegion:           viper.GetString("upload_region"),
 		CustomS3UploadBucket:   viper.GetString("custom_s3_bucket"),
 		CustomS3Region:         viper.GetString("custom_s3_region"),
+		APIKeyFilepath:         viper.GetString("api_key_filepath"),
 	}
 
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -247,9 +247,8 @@ func gatherAPIKeyFromVolume(config KubeAgentConfig) string {
 func getKeyFromFileVolume(filepath string) string {
 	key, err := os.ReadFile(filepath)
 	if err != nil {
-		log.Fatalf("error attempting to collect cloudability api key from file: %s with err: %v. "+
-			"Ensure the cloudability api key is either set as an environment variable or the correct volume mounting "+
-			"is in place to allow the agent to access the file storing the api key", filepath, err)
+		log.Warnf("error attempting to collect cloudability api key from file: %s with err: %v", filepath, err)
+		return ""
 	}
 	return string(key)
 }

--- a/kubernetes/kubernetes.go
+++ b/kubernetes/kubernetes.go
@@ -137,9 +137,8 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 	kubeAgent := newKubeAgent(ctx, config)
 
 	customS3Mode := isCustomS3UploadEnvsSet(&kubeAgent)
-
 	if !customS3Mode {
-		kubeAgent.APIKey = gatherAPIKeyFromVolume(config)
+		kubeAgent.APIKey = getAPIKey(config)
 	}
 	// Log start time
 	kubeAgent.AgentStartTime = time.Now()
@@ -221,7 +220,7 @@ func CollectKubeMetrics(config KubeAgentConfig) {
 
 }
 
-func gatherAPIKeyFromVolume(config KubeAgentConfig) string {
+func getAPIKey(config KubeAgentConfig) string {
 	key := getKeyFromFileVolume(config.APIKeyFilepath)
 	// key from volume is empty, attempt to pull from environment variable
 	if key == "" {
@@ -243,7 +242,7 @@ func gatherAPIKeyFromVolume(config KubeAgentConfig) string {
 	return key
 }
 
-// getKeyFromFileVolume attempts to gather the base64 encoded api key from filepath
+// getKeyFromFileVolume attempts to gather the api key from filepath
 func getKeyFromFileVolume(filepath string) string {
 	key, err := os.ReadFile(filepath)
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // VERSION is the current version of the agent
-var VERSION = "2.12.1"
+var VERSION = "2.13.0"


### PR DESCRIPTION
#### What does this PR do?
Adds support and recommendation to mount the CLOUDABILITY_API_KEY from a k8s secret as a volume instead of reading directly from an environment variable.

Updated a minor version instead of a patch because helm provisioning resources did get altered a bit.
#### Where should the reviewer start?
helm chart & kubernetes.go
#### How should this be manually tested?
Deployed on a test cluster using helm command.
Ensured the image can still be deployed using environment variables ensuring backwards compatibility.
#### Any background context you want to provide?
We are still planning to support env vars, this is just updating the default method in helm and adding support for volume mounting in the metrics-agent code
#### What picture best describes this PR (optional but encouraged)?

#### What are the relevant Github Issues?

#### Developer Done List

- [ ] Tests Added/Updated
- [ ] Updated README.md
- [ ] Verified backward compatible
- [ ] Verified database migrations will not be catastrophic
- [ ] Considered Security, Availability and Confidentiality

#### For the Reviewer:

#### By approving this PR, the reviewer acknowledges that they have checked all items in this done list.

#### Reviewer/Approval Done List

- [ ] Tests Pass Locally
- [ ] CI Build Passes
- [ ] Verified README.md is updated
- [ ] Verified changes are backward compatible
- [ ] Reviewed impact to Security, Availability and Confidentiality (if issue found, add comments and request changes)